### PR TITLE
design-coverage: polish the narrative render for human consumption

### DIFF
--- a/skill-tests/design-coverage/tests/test_renderer_report.py
+++ b/skill-tests/design-coverage/tests/test_renderer_report.py
@@ -30,3 +30,40 @@ def test_matrix_header_is_platform_neutral():
     md = render_report(data)
     assert "| Figma frame | Code screen | Status |" in md
     assert "Android screen" not in md
+
+
+def test_summary_bullets_carry_severity_emoji():
+    """Polish #7 — each summary bullet is prefixed with a severity emoji
+    so the reader can scan the list visually before reading any text."""
+    data = {
+        "summary": [
+            {"severity": "error", "message": "missing resource picker", "screen": "B"},
+            {"severity": "warn", "message": "toolbar collapse", "screen": "C"},
+            {"severity": "info", "message": "layout polish", "screen": "A"},
+        ],
+        "matrix": [],
+    }
+    md = render_report(data)
+    # Emoji appears before the [SEVERITY] tag on each bullet
+    assert "- 🔴 [ERROR]" in md
+    assert "- 🟠 [WARN]" in md
+    assert "- ℹ️ [INFO]" in md
+
+
+def test_matrix_rows_carry_status_emoji():
+    """Polish #7 — each matrix row prefixes its status cell with an emoji
+    matching the severity convention used by the narrative render."""
+    data = {
+        "summary": [],
+        "matrix": [
+            {"figma_frame": "F1", "android_screen": "A", "status": "present"},
+            {"figma_frame": "F2", "android_screen": None, "status": "new-in-figma"},
+            {"figma_frame": "F3", "android_screen": "B", "status": "restructured"},
+            {"figma_frame": "F4", "android_screen": "C", "status": "missing"},
+        ],
+    }
+    md = render_report(data)
+    assert "✅ present" in md
+    assert "⚪ new-in-figma" in md
+    assert "🟡 restructured" in md
+    assert "🔴 missing" in md

--- a/skills/design-tooling/design-coverage/SKILL.md
+++ b/skills/design-tooling/design-coverage/SKILL.md
@@ -212,13 +212,7 @@ The summary is for a designer / engineer reviewer who has ~2 minutes before thei
 
 ### Required structure
 
-1. **Non-deterministic banner** at the very top — a comment explaining provenance:
-
-   ```
-   <!-- Rendered by the main session from 06-report.json on <ISO-date>.
-        Non-deterministic — re-running /design-coverage may produce different
-        prose. The deterministic audit view is 06-report.md. -->
-   ```
+1. **Non-deterministic banner** — write this HTML comment verbatim at the very top of `06-summary.md` (do **not** wrap it in a code fence; the banner is an actual HTML comment, not a code example): `<!-- Rendered by the main session from 06-report.json on <ISO-date>. Non-deterministic — re-running /design-coverage may produce different prose. The deterministic audit view is 06-report.md. -->`
 
 2. **One-line verdict** immediately after the title: `> **Verdict:** 🟢 Ready to ship` / `🟡 Caveats below` / `🔴 Not ready to ship: <one-sentence reason>`. Pick color by highest-severity summary entry (any `error` → red; any `warn` and no error → yellow; else green). The reason cites the specific gap that blocks shipping ("the Resource Picker modal has no Figma frame"), not a count ("2 errors need review").
 

--- a/skills/design-tooling/design-coverage/SKILL.md
+++ b/skills/design-tooling/design-coverage/SKILL.md
@@ -206,16 +206,46 @@ exists in the run directory.
 
 ## Final output
 
-After stage 6 writes the deterministic `<run-dir>/06-report.md` (audit view), run the **stage-6 narrative render** in the main session — do NOT dispatch a subagent for this step. Read `<run-dir>/06-report.json` and render a verdict-first summary to `<run-dir>/06-summary.md` with this structure:
+After stage 6 writes the deterministic `<run-dir>/06-report.md` (audit view), run the **stage-6 narrative render** in the main session — do NOT dispatch a subagent for this step. Read `<run-dir>/06-report.json` and render a verdict-first summary to `<run-dir>/06-summary.md`.
 
-1. **One-line verdict** at the top: `> **Verdict:** 🟢 Ready to ship` / `🟡 Caveats below` / `🔴 Not ready to ship: <one-sentence reason>`. Pick color by highest-severity summary entry: any `error` → red; any `warn` (no error) → yellow; else green.
-2. **Severity tally table** (counts of error / warn / info summary entries + counts of matrix statuses: `missing`, `new-in-figma`, `restructured`, `present`).
-3. **Sections per severity bucket** — start with 🔴 errors, each as a concise paragraph citing `code_ref` / `figma_ref` / evidence. Then 🟠 warnings, grouped by screen. Then 🟡 restructured rows (if any) under an optional "verify intent, don't fix" banner. `new-in-figma` counts get a collapsed summary, not an enumeration.
-4. **Where to start** section at the bottom — 2-4 bullets prioritizing errors over warnings.
+The summary is for a designer / engineer reviewer who has ~2 minutes before their next meeting. Optimize for that reader: prose-first, prioritized, collapsed where noisy. Do NOT mechanically enumerate.
 
-Write the summary via a simple Bash heredoc or `Write` call. The rendered file has a header comment noting it is non-deterministic (re-running may produce different prose). The deterministic audit view remains at `06-report.md`.
+### Required structure
 
-Then print the path to **both** files:
+1. **Non-deterministic banner** at the very top — a comment explaining provenance:
+
+   ```
+   <!-- Rendered by the main session from 06-report.json on <ISO-date>.
+        Non-deterministic — re-running /design-coverage may produce different
+        prose. The deterministic audit view is 06-report.md. -->
+   ```
+
+2. **One-line verdict** immediately after the title: `> **Verdict:** 🟢 Ready to ship` / `🟡 Caveats below` / `🔴 Not ready to ship: <one-sentence reason>`. Pick color by highest-severity summary entry (any `error` → red; any `warn` and no error → yellow; else green). The reason cites the specific gap that blocks shipping ("the Resource Picker modal has no Figma frame"), not a count ("2 errors need review").
+
+3. **Next 5 actions** — a numbered list of the 5 most actionable rows the reader should work on first (errors before warnings, highest-severity warnings before lower). One sentence each, imperative voice, beginning with a verb ("Ask design to add…", "Confirm with product whether…", "Drop the legacy X path…"). This is what the reader reads in the first 30 seconds — it must be the top of the file, not buried after the tally.
+
+4. **Severity tally table** — counts of 🔴/🟠/ℹ️ summary entries + counts of matrix statuses (`missing`, `new-in-figma`, `restructured`, `present`). Use the emoji in the table cells, not just the headers.
+
+5. **Sections per severity bucket**, in this order:
+   - **🔴 Errors** — each error as its own subsection. Required content per error: the row's `code_ref` / `figma_ref`, one-sentence reasoning, and a concrete "what to do" sentence that starts with a verb ("Ask design to…", "Document that…", "Drop the X branch if…"). **No ambiguity-punting prose** like "needs explicit product confirmation" without a proposed ask.
+   - **🟠 Warnings** — group by **underlying design decision**, not by severity tag or by clarification Q-ID. Cluster related items: "all three cancel-with-auto-email variants trace to one dropped feature — one fix". The group name should be in reviewer-facing product language ("Bottom toolbar collapse", "Notes screen extraction", "Status-chip consolidation"), not audit shorthand ("Q10/Q11 fold"). If one design decision produces > 20 warning rows, the decision itself is a cluster worth calling out in its own subsection.
+   - **🟡 Restructured** — same grouping principle (by design decision, not by Q-ID). Open with a banner reminding the reader these are intentional moves, not bugs: *"The N restructured rows below are not bugs — they are places the legacy shape is being intentionally rebuilt. Review to confirm intent; do NOT treat as defects."*
+   - **⚪ New in Figma** — summarize into themed buckets (`Coachmarks`, `Milestones`, `Skeleton loading`, `Haptics`, …), counts only. Do NOT enumerate individual rows — link to `06-report.md` for the full list.
+
+6. **Wrap long sections in `<details>`** — any section with ≥ 20 rows MUST be wrapped in `<details><summary>…</summary>…</details>` so GitHub collapses it by default. The `<summary>` must carry the bucket name AND the row count so the reader can see the scale without expanding (example: `<summary><b>Bottom toolbar collapse — 38 rows</b></summary>`).
+
+7. **Where to start** — 3–5 numbered bullets at the bottom prioritizing errors over warnings, with concrete next actions. Separate from "Next 5 actions" at the top — that's raw-priority; this is operator-guidance ("Walk the 62 missing rows with product in one session; decide which are dropped vs oversight").
+
+### Forbidden / pitfalls
+
+- **Do NOT group by severity tag alone** ("🟠 Warnings" is a section header, not a group). Always cluster related rows under a design-decision name.
+- **Do NOT enumerate the full matrix.** If a section would exceed ~30 bullets, collapse it with `<details>` or bucket it.
+- **Do NOT paste verbatim clarifications.** They live in `03-clarifications.md`; link to that file.
+- **Do NOT soften error action prose.** "Needs confirmation" is wrong. "Ask design to add a frame for the Resource Picker, or document that resource-required appointments are out of scope for the new flow" is right.
+
+### Mechanics
+
+Use the `Write` tool to create `06-summary.md` directly. Then print the path to both files so the user can open either:
 
 ```
 Audit view:     <run-dir>/06-report.md

--- a/skills/design-tooling/design-coverage/lib/renderer.py
+++ b/skills/design-tooling/design-coverage/lib/renderer.py
@@ -110,19 +110,33 @@ def render_comparison(data: Dict[str, Any]) -> str:
         )
     return "\n".join(lines) + "\n"
 
+_SEVERITY_EMOJI = {"error": "🔴", "warn": "🟠", "info": "ℹ️"}
+_STATUS_EMOJI = {
+    "missing": "🔴",
+    "restructured": "🟡",
+    "new-in-figma": "⚪",
+    "present": "✅",
+}
+
+
 def render_report(data: Dict[str, Any]) -> str:
     lines = [_header(data, "Design Coverage Report")]
     severity_order = {"error": 0, "warn": 1, "info": 2}
     summary = sorted(data.get("summary", []), key=lambda s: severity_order.get(s["severity"], 99))
     lines.append("\n## Summary\n")
     for s in summary:
+        emoji = _SEVERITY_EMOJI.get(s["severity"], "")
         screen = f" ({s['screen']})" if s.get("screen") else ""
-        lines.append(f"- [{s['severity'].upper()}]{screen} {s['message']}")
+        prefix = f"{emoji} " if emoji else ""
+        lines.append(f"- {prefix}[{s['severity'].upper()}]{screen} {s['message']}")
     lines.append("\n## Coverage Matrix\n")
     # Column header is platform-neutral; the JSON key stays `android_screen`
     # for schema compatibility (see spec "Known limitations").
     lines.append("| Figma frame | Code screen | Status |")
     lines.append("|---|---|---|")
     for m in data.get("matrix", []):
-        lines.append(f"| {m['figma_frame']} | {m.get('android_screen') or '—'} | {m['status']} |")
+        status = m["status"]
+        status_emoji = _STATUS_EMOJI.get(status, "")
+        status_cell = f"{status_emoji} {status}" if status_emoji else status
+        lines.append(f"| {m['figma_frame']} | {m.get('android_screen') or '—'} | {status_cell} |")
     return "\n".join(lines) + "\n"

--- a/skills/design-tooling/design-coverage/stages/06-report-generator.md
+++ b/skills/design-tooling/design-coverage/stages/06-report-generator.md
@@ -104,3 +104,23 @@ If a deployment needs `missing` rows on a matrix (e.g., for a code-first coverag
 ## Narrative summary (NOT this stage)
 
 This stage writes the deterministic audit view (`06-report.md`). The verdict-first narrative summary at `06-report.json` → `06-summary.md` is rendered by the **main session**, not a subagent, once this stage returns. See SKILL.md § "Final output" for the required structure. Keeping the narrative render out-of-stage means this stage stays deterministic and testable; the narrative is explicitly labeled non-deterministic.
+
+## Scope fence — what this stage MUST NOT write
+
+This stage writes exactly two files:
+
+- `<run_dir>/06-report.json` (deterministic JSON, schema-validated)
+- `<run_dir>/06-report.md` (deterministic Markdown from `render_report`)
+
+Explicitly forbidden additions to `06-report.md`:
+
+- **Do NOT append a verbatim `## Clarifications Q01–QNN` dump.** Stage 3 already writes the full Q&A to `03-clarifications.json` / `03-clarifications.md`. Duplicating the verbatim Q&A in the report file bloats it without new information and couples stage 6 to stage 3's prose. If `06-report.md` needs to reference clarifications, add a one-line pointer:
+
+  ```markdown
+  _Stage 3 Q&A (verbatim): see [03-clarifications.md](./03-clarifications.md)._
+  ```
+
+- **Do NOT write `06-summary.md`.** The main session owns the narrative render — if you find a `06-summary.md` already in the run dir (from a prior run), leave it alone.
+- **Do NOT rewrite any severity or status judgement from `05-comparison.json`.** Stage 5 is the source of truth; your job is to project those rows into the report shape, not re-adjudicate them. If a verdict looks wrong, that's a stage 5 problem — surface it as an error, don't paper over it.
+
+Freelancing extra prose sections (e.g., "Severity tally insights", "Review roadmap", "Reasoning notes") also belongs in `06-summary.md`, not here.


### PR DESCRIPTION
## Summary

First dogfood run of the platform-agnostic skill (against MindBodyPOS #5349's Figma file from this repo's smoke worktree) produced a `06-summary.md` that was functional but visibly thinner than iOS PR #5349's equivalent artifact for the same flow: ambiguity-punting error prose, mechanical clustering by clarification Q-ID instead of by design decision, 300-line verbatim Q&A dump in `06-report.md`, no collapsibles on long sections, no "first 30 seconds" action list at the top.

This PR closes the gap by tightening the prompts in `SKILL.md § Final output` and `stages/06-report-generator.md`, lifting the stronger wording directly from iOS PR #5349's `.claude/skills/design-coverage/SKILL.md`. No schema or pipeline changes — pure prompt + renderer polish.

## What changes

**`SKILL.md § Final output`** — rewritten render template with:
- "Next 5 actions" numbered list immediately after the verdict (first 30 seconds' worth of content, not buried after the tally)
- Required "Ask design to… / Document that…" imperative-verb phrasing on every error row (no more "needs explicit product confirmation" punts)
- Warnings cluster by **underlying design decision** in reviewer language, not by severity or Q-ID (verbatim wording lifted from iOS PR: *"Group findings the way a reviewer would group them, not by severity tag. Cluster related items — 'all three cancel-with-auto-email variants trace to one dropped feature — one fix'."*)
- Sections ≥ 20 rows MUST be wrapped in `<details><summary>name — N rows</summary>…</details>` (GitHub collapses by default)
- New-in-figma always summarized into themed buckets, never enumerated
- "Forbidden / pitfalls" section calling out the failure modes observed in the first dogfood

**`stages/06-report-generator.md`** — scope fence:
- Explicitly forbids appending a verbatim `## Clarifications Q01–QNN` dump to `06-report.md` (the first dogfood's subagent freelanced this, adding 300 lines of duplicate content already in `03-clarifications.md`). Allowed pattern is a one-line link.
- Explicitly forbids stage-6 from writing `06-summary.md` or freelancing extra prose sections like "Severity tally insights" / "Review roadmap" — those belong in the main-session narrative.

**`lib/renderer.render_report`** — row-level severity emoji in both summary bullets and matrix status cells:
- `- 🔴 [ERROR] (screen) message` instead of `- [ERROR] (screen) message`
- `🔴 missing` / `🟡 restructured` / `⚪ new-in-figma` / `✅ present` in the matrix status column
- Text tags preserved so tooling that greps for `[ERROR]` or parses the status column keeps working. Two new tests pin the emoji.

## Explicitly NOT included

Polish #5 from the dogfood follow-up list ("Was this report useful?" feedback footer with next-run re-read loop) was deferred at user direction; would introduce a new orchestrator read-path and is scope-separate from render polish.

## Files Changed

| File | Change |
|---|---|
| `skills/design-tooling/design-coverage/SKILL.md` | Rewrote § Final output with required structure, forbidden patterns, and the iOS-lifted grouping wording |
| `skills/design-tooling/design-coverage/stages/06-report-generator.md` | Added scope-fence section forbidding verbatim Q&A dump and freelanced prose sections |
| `skills/design-tooling/design-coverage/lib/renderer.py` | Row-level emoji in `render_report` (summary bullets + matrix status cells) |
| `skill-tests/design-coverage/tests/test_renderer_report.py` | Two new tests pinning the summary-bullet and matrix-cell emoji |

## Testing

- `python -m pytest skill-tests/ -q` → **98 passed** (96 previous + 2 new emoji tests)
- `python scripts/validate.py` → OK

## Related

- Dogfood comparison that drove this: `docs/design-coverage-dogfood/2026-04-22-appointment-details-smoke/comparison.md` (landed in #8)
- Source wording references: iOS PR mindbody/MindBodyPOS#5349 `.claude/skills/design-coverage/SKILL.md` lines 128–160
- Supersedes spec bullet "Stage-06 narrative-render pass" under follow-ups