### PR TITLE
Add UI/design deferral workflow to pr-autopilot

### DIFF
--- a/skills/pr-tooling/pr-autopilot/SKILL.md
+++ b/skills/pr-tooling/pr-autopilot/SKILL.md
@@ -9,7 +9,7 @@ description: >
   when the user says "publish the PR", "ship with autopilot", "run
   pr-autopilot", "/pr-autopilot", or similar.
 argument-hint: "[iteration-cap]"
-allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, ScheduleWakeup
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, ScheduleWakeup, AskUserQuestion
 ---
 
 # pr-autopilot
@@ -81,9 +81,14 @@ Phase 4 — CI gate (if step 08 exited quiescent, not on cap/runaway)
 7. If red, perform `~/.claude/skills/pr-loop-lib/steps/10-ci-failure-classify.md`.
    Up to 3 re-entries of Phase 3. On cap, proceed to step 8.
 
-Phase 5 — Report
+Phase 5 — Report (and optional UI-deferred approval)
 
-8. Perform `~/.claude/skills/pr-loop-lib/steps/11-final-report.md`. End.
+8. Perform `~/.claude/skills/pr-loop-lib/steps/11-final-report.md`.
+   If `context.ui_deferred_items` is non-empty, step 11 also runs an
+   interactive approval phase (per-item apply / reject / skip via
+   `AskUserQuestion`). Approved items re-enter step 04 with
+   `UI_DEFERRAL_OVERRIDE=true` and go through step 06 for commit +
+   push. Then end.
 
 ## Hard rules (from user global CLAUDE.md)
 

--- a/skills/pr-tooling/pr-followup/SKILL.md
+++ b/skills/pr-tooling/pr-followup/SKILL.md
@@ -7,7 +7,7 @@ description: >
   iteration. Use when the user says "follow up on the PR", "new comments
   came in", "address the latest review feedback", "/pr-followup", or similar.
 argument-hint: "[pr-number] [iteration-cap]"
-allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, ScheduleWakeup
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, ScheduleWakeup, AskUserQuestion
 ---
 
 # pr-followup

--- a/skills/pr-tooling/pr-loop-lib/references/context-schema.md
+++ b/skills/pr-tooling/pr-loop-lib/references/context-schema.md
@@ -56,6 +56,7 @@ Required fields are marked as such.
 | `verifier_judgements` | array of objects | default `[]` | Step 04 verifier outputs, one per verified fixer return |
 | `files_changed_this_iteration` | array of strings | default `[]` | Union of fixer file changes |
 | `needs_human_items` | array of objects | default `[]` | Items flagged for user attention |
+| `ui_deferred_items` | array of objects | default `[]` | Items the fixer judged to be UI / design / copy changes; deferred to end-of-run user approval. Each entry: `{feedback_id, thread_id?, path?, line?, author, body, proposal, reply_text}`. Step 11 prompts the user and may re-enter step 04 scoped to approved items. |
 | `sanity_check_passed` | object | default `{}` | `{ <iteration>: <bool> }` |
 
 ## CI gate
@@ -101,7 +102,7 @@ Required fields are marked as such.
 
 ```json
 {
-  "verdict": "fixed | fixed-differently | replied | not-addressing | needs-human",
+  "verdict": "fixed | fixed-differently | replied | not-addressing | needs-human | ui-deferred",
   "feedback_id": "string",
   "feedback_type": "inline | issue | review | thread",
   "reply_text": "string (markdown)",
@@ -111,6 +112,10 @@ Required fields are marked as such.
   "cluster_assessment": "string or null"
 }
 ```
+
+`ui-deferred` is never emitted with a non-empty `files_changed`. Step
+04's validation rolls back and demotes to `needs-human` if a fixer
+violates this.
 
 ### VerifierJudgement (used in `verifier_judgements`)
 
@@ -124,6 +129,11 @@ Required fields are marked as such.
   "dispatched_at": "ISO-8601 string"
 }
 ```
+
+`fixer_verdict_after` does NOT include `ui-deferred`: verification
+only runs when the fixer originally edited files (verdict `fixed` or
+`fixed-differently`), so the policy ladder can never land on
+`ui-deferred` post-hoc.
 
 ## Validation rules (applied by the LLM on every write)
 

--- a/skills/pr-tooling/pr-loop-lib/references/context-schema.md
+++ b/skills/pr-tooling/pr-loop-lib/references/context-schema.md
@@ -57,6 +57,7 @@ Required fields are marked as such.
 | `files_changed_this_iteration` | array of strings | default `[]` | Union of fixer file changes |
 | `needs_human_items` | array of objects | default `[]` | Items flagged for user attention |
 | `ui_deferred_items` | array of objects | default `[]` | Items the fixer judged to be UI / design / copy changes; deferred to end-of-run user approval. Each entry: `{feedback_id, thread_id?, path?, line?, author, body, proposal, reply_text}`. Step 11 prompts the user and may re-enter step 04 scoped to approved items. |
+| `ui_deferred_actionable` | array of objects | default `[]` | Scoped overlay written by step 11 before re-dispatching approved `ui_deferred_items`. During that one step-04 invocation, the dispatcher reads its actionable list from this field in place of `context.actionable`. Never replaces `context.actionable`; the persisted top-level `actionable` is left unchanged. Same shape as the individual items in `context.actionable`. |
 | `sanity_check_passed` | object | default `{}` | `{ <iteration>: <bool> }` |
 
 ## CI gate

--- a/skills/pr-tooling/pr-loop-lib/references/fixer-prompt.md
+++ b/skills/pr-tooling/pr-loop-lib/references/fixer-prompt.md
@@ -78,8 +78,10 @@ UI / design deferral (verdict `ui-deferred`)
   with `fixed` as usual and mention in `reason` that a UI-only sub-point
   was noted. Do not split into two returns.
   When returning `ui-deferred`:
-    - `files_changed` MUST be `[]`. The orchestrator halts the skill if
-      a `ui-deferred` return has touched files.
+    - `files_changed` MUST be `[]`. If a `ui-deferred` return has
+      touched files, the orchestrator rolls back those edits and
+      demotes the result to `needs-human` while continuing the run
+      (see `steps/04-dispatch-fixers.md` — "ui-deferred guard").
     - `reply_text` starts with the quoted feedback sentence followed by
       `Deferred for user review: <one-line proposal>`. The orchestrator
       posts this reply but does NOT resolve the thread.

--- a/skills/pr-tooling/pr-loop-lib/references/fixer-prompt.md
+++ b/skills/pr-tooling/pr-loop-lib/references/fixer-prompt.md
@@ -20,6 +20,7 @@ PR context
   PR title: {{PR_TITLE}}
   base branch: {{BASE_BRANCH}}
   head commit: {{HEAD_SHA}}
+  ui deferral override: {{UI_DEFERRAL_OVERRIDE}}   (one of: `false` | `true`)
 
 Feedback details
   surface: {{SURFACE_TYPE}}   (one of: inline | issue | review | thread)
@@ -37,6 +38,9 @@ Your task
      {{FILE_PATH}} and adjacent files in the same directory if the
      feedback references them.
   2. Decide whether the feedback is:
+       - a UI / design / visual-appearance change (verdict `ui-deferred`);
+         see "UI / design deferral" below — this takes precedence over
+         `fixed`/`replied` when it applies;
        - valid and actionable with a clear code fix;
        - valid but already addressed in the current code (a reply is enough);
        - factually wrong about the code (provide evidence in the reply);
@@ -52,10 +56,48 @@ Your task
      are addressing, followed by one of:
        - "Addressed: <brief description of the fix>"
        - "Not addressing: <reason with evidence, e.g., 'null check already exists at line 85'>"
+       - "Deferred for user review: <one-line description of the proposed UI change>"
+         (used with verdict `ui-deferred`).
+
+UI / design deferral (verdict `ui-deferred`)
+  The orchestrator auto-commits code fixes, but **UI / design feedback must
+  be surfaced to the user for explicit approval**. Return `ui-deferred`
+  (and do NOT edit any files) when the feedback is primarily about:
+    - visual appearance — color, gradient, shadow, contrast, opacity;
+    - layout, spacing, padding, margin, alignment, grid, flex geometry;
+    - typography — font family, size, weight, line-height, letter-spacing;
+    - component styling, iconography, imagery, empty-state visuals,
+      animation/transition feel;
+    - user-facing copy / wording / tone (microcopy, button labels,
+      placeholders, help text);
+    - pure UX polish ("this feels cramped", "move this button above the
+      fold", "the modal should close on backdrop click").
+  If the feedback is mixed — part UI, part logic/accessibility/a11y-code
+  (e.g., missing `aria-label`, keyboard-trap bug, unhandled error state
+  that happens to show a broken UI) — treat the logic/a11y-code portion
+  with `fixed` as usual and mention in `reason` that a UI-only sub-point
+  was noted. Do not split into two returns.
+  When returning `ui-deferred`:
+    - `files_changed` MUST be `[]`. The orchestrator halts the skill if
+      a `ui-deferred` return has touched files.
+    - `reply_text` starts with the quoted feedback sentence followed by
+      `Deferred for user review: <one-line proposal>`. The orchestrator
+      posts this reply but does NOT resolve the thread.
+    - Put the one-line proposal (what you *would* change, if approved)
+      into `reason` as well, so the final-report prompt can show it to
+      the user verbatim.
+  **UI deferral override.** If the PR-context line reads
+  `ui deferral override: true`, the user has already reviewed this
+  feedback in the final-report prompt and explicitly approved the
+  change. In that case, `ui-deferred` is NOT a valid verdict — pick
+  one of `fixed`, `fixed-differently`, `replied`, `not-addressing`,
+  or `needs-human` and proceed to apply the change directly. When
+  override is `false` (the default during the loop), follow the
+  deferral rules above.
 
 Return format (exactly these keys as JSON in your final message)
   {
-    "verdict": "fixed" | "fixed-differently" | "replied" | "not-addressing" | "needs-human",
+    "verdict": "fixed" | "fixed-differently" | "replied" | "not-addressing" | "needs-human" | "ui-deferred",
     "feedback_id": "{{FEEDBACK_ID}}",
     "feedback_type": "{{SURFACE_TYPE}}",
     "reply_text": "markdown reply starting with `> quoted...`",

--- a/skills/pr-tooling/pr-loop-lib/references/invariants.md
+++ b/skills/pr-tooling/pr-loop-lib/references/invariants.md
@@ -83,11 +83,12 @@ equivalent predicates live in `P02.*`.
 | # | Predicate |
 |---|---|
 | S04.1 | `len(agent_returns) == len(dispatch_units)` where dispatch_units is clusters + individual items |
-| S04.2 | Every return's `verdict` is one of the 5 allowed values |
+| S04.2 | Every return's `verdict` is one of the 6 allowed values (`fixed`, `fixed-differently`, `replied`, `not-addressing`, `needs-human`, `ui-deferred`) per the AgentReturn schema in `context-schema.md` |
 | S04.3 | Every entry in `verifier_judgements` has a matching entry in `agent_returns` (by `feedback_id`), AND every `feedback_id` whose fixer invocation produced a `fixed`/`fixed-differently` verdict (recorded via the `subagent_return` log event) has an entry in `verifier_judgements`. Demotion in the policy ladder does NOT excuse a missing verifier_judgement — judgements are keyed off the fixer's ORIGINAL verdict, not the post-ladder one. |
 | S04.4 | `files_changed_this_iteration` equals the union of `files_changed` across all returns |
 | S04.5 | No file in `files_changed_this_iteration` has a path outside `context.repo_root` |
 | S04.7 | After the policy ladder resolves for the current dispatch, no surviving fixer's `files_changed` contains an entry that also appears in any rolled-back fixer's `files_changed` unless a `fixer_reverify` log event for that survivor exists this step with the overlapping files listed in `overlap_files`. See `04-dispatch-fixers.md` — "Overlap re-verify". |
+| S04.8 | Every return in `agent_returns` with `verdict == "ui-deferred"` has `files_changed == []` AND a matching entry in `context.ui_deferred_items` (by `feedback_id`). A `ui-deferred` return that touched files must have been rolled back and demoted to `needs-human` by step 04's `ui-deferred` guard — verified by the presence of a `ui_deferred_touched_files` log event and the absence of the item from `ui_deferred_items`. |
 
 ### Step 04.5 — local-verify
 
@@ -133,6 +134,7 @@ equivalent predicates live in `P02.*`.
 |---|---|
 | S11.1 | `termination_reason` is set |
 | S11.2 | Lock **directory** (Primitive A in `state-protocol.md`) has been removed by the time this step completes. Verified via `test ! -d "<repo-root>/.pr-autopilot/pr-<N>.lock"`. Under α the lock was a flat file and this read "Lock file has been removed"; under β the directory-as-lock form requires `rm -rf`, but the presence-check predicate is unchanged in intent — the path must not exist. |
+| S11.3 | If `len(context.ui_deferred_items) > 0` at step entry, the log contains either exactly one `ui_deferred_prompt_skipped` event for this run OR one `ui_deferred_decision` event per item (matched by `feedback_id`), with `decision ∈ {apply, reject, skip}`. Re-dispatch of approved items is audited via the normal `subagent_dispatch` / `subagent_return` events on step 04, with each entry's `feedback_id` matching the approved item. |
 
 ### Step 04g — post-open /code-review invocation (pr-autopilot)
 

--- a/skills/pr-tooling/pr-loop-lib/references/log-format.md
+++ b/skills/pr-tooling/pr-loop-lib/references/log-format.md
@@ -75,6 +75,9 @@ Rules:
 | `verifier_nonce_collision` | `{slot, body_sample}` — emitted by the verifier prompt renderer when raw content in one of the untrusted slots contains the nonce literal. `slot` is `feedback` / `reason` / `diff`; `body_sample` is the first 200 chars of the offending input. First collision triggers nonce regeneration; a second collision aborts the verifier call |
 | `fixer_nonce_collision` | `{}` — emitted by the fixer dispatch when the comment body contains the fixer nonce literal. Distinct from `verifier_nonce_collision` (which covers the verifier's three slots). First collision triggers nonce regeneration; a second collision escalates the dispatch unit to `needs-human` |
 | `wait_clamped` | `{requested_minutes, effective_minutes, reason}` — emitted by `pr-loop-lib/steps/01-wait-cycle.md` when `context.wait_override_minutes` is less than the 10-minute floor and gets clamped up. `requested_minutes` is the raw user input, `effective_minutes` is always 10. `reason` is a short string explaining the floor (e.g., `"reviewer-bot response window"`). Informational only — the loop continues with the clamped value |
+| `ui_deferred_touched_files` | `{feedback_id, files_changed}` — emitted by step 04's validation when a fixer return with `verdict == "ui-deferred"` arrived with a non-empty `files_changed`. The orchestrator rolls back and demotes the return to `needs-human`; this event is the audit trail for S04.8. |
+| `ui_deferred_decision` | `{feedback_id, decision}` — emitted by step 11's UI-deferred approval phase, one per item, `decision ∈ {apply, reject, skip}`. `apply` triggers a re-dispatch through step 04 with `UI_DEFERRAL_OVERRIDE=true`. |
+| `ui_deferred_prompt_skipped` | `{reason, count}` — emitted by step 11 when the approval prompt could not run (e.g., non-interactive host). `count` is `len(context.ui_deferred_items)` at the time the prompt would have fired. |
 
 ## Truncation
 

--- a/skills/pr-tooling/pr-loop-lib/steps/04-dispatch-fixers.md
+++ b/skills/pr-tooling/pr-loop-lib/steps/04-dispatch-fixers.md
@@ -281,10 +281,17 @@ guard above passes):
   `context.files_changed_this_iteration` — `ui-deferred` never edits
   code during the loop.
 
-Deferred items do NOT block quiescence. Their thread reply is the
-self-login reply that step 08 uses to mark the thread handled, so
-Filter A will exclude them on subsequent iterations even though the
-thread is still open on the platform.
+Deferred items do NOT block quiescence. Step 07 posts a self-login
+reply on the thread, but that alone does NOT cause Filter A to drop
+the original reviewer comment on the next fetch — Filter A's
+self-login pre-filter only drops the reply itself; the original
+comment is still eligible for re-triage via the "new-since"
+timestamp check. The mechanism that actually suppresses re-triage
+is step 08 advancing `context.last_handled_timestamp = now` on
+ui-deferred-present quiescent exits (see
+`steps/08-quiescence-check.md` exit condition #2). The thread
+remains open on the platform; the cursor advance keeps the loop
+from re-dispatching the same item.
 
 ## `needs-human` handling
 

--- a/skills/pr-tooling/pr-loop-lib/steps/04-dispatch-fixers.md
+++ b/skills/pr-tooling/pr-loop-lib/steps/04-dispatch-fixers.md
@@ -55,7 +55,11 @@ For each unit:
 5. Substitute remaining placeholders: `{{OWNER}}`, `{{REPO}}`, `{{PR_NUMBER}}`,
    `{{PR_TITLE}}`, `{{BASE_BRANCH}}`, `{{HEAD_SHA}}`, `{{SURFACE_TYPE}}`,
    `{{FILE_PATH}}`, `{{LINE_NUMBER}}`, `{{AUTHOR_LOGIN}}`, `{{AUTHOR_TYPE}}`,
-   `{{CREATED_AT}}`, `{{COMMENT_BODY_VERBATIM}}`, `{{FEEDBACK_ID}}`.
+   `{{CREATED_AT}}`, `{{COMMENT_BODY_VERBATIM}}`, `{{FEEDBACK_ID}}`,
+   `{{UI_DEFERRAL_OVERRIDE}}`. `{{UI_DEFERRAL_OVERRIDE}}` is the
+   literal string `false` during the normal loop and `true` only when
+   step 11's UI-deferred approval phase re-enters this step for items
+   the user explicitly approved.
 6. For cluster units, additionally substitute the cluster-brief XML block.
 7. Spawn an agent via the host platform's agent-dispatch mechanism (on
    Claude Code: `Agent` tool with `subagent_type: "general-purpose"`,
@@ -73,6 +77,16 @@ Validate each return:
   outside the repo root.
 - `reply_text` is non-empty when verdict is not `not-addressing` of the
   `suspicious` flavor (those have canned replies from step 03).
+- **`ui-deferred` guard:** if `verdict == "ui-deferred"` AND
+  `files_changed` is non-empty, the fixer violated the contract in
+  `references/fixer-prompt.md` ("UI / design deferral"). Treat this as
+  an invariant fail: log `ui_deferred_touched_files` with
+  `{feedback_id, files_changed}`, roll back via
+  `git checkout -- <files_changed>`, clear `files_changed = []`, and
+  demote the return to `needs-human` with reason
+  "fixer returned ui-deferred but edited files; rolled back". Do NOT
+  collect into `context.ui_deferred_items` in this case — the fixer's
+  judgement is no longer trusted for this item.
 
 ## Fixer-output verification (mandatory)
 
@@ -240,8 +254,9 @@ Per `pr-loop-lib/references/invariants.md`:
 
 ### Skip conditions
 
-- Return verdicts `replied`, `not-addressing`, `needs-human` → no
-  verification runs. These already declined to change code.
+- Return verdicts `replied`, `not-addressing`, `needs-human`,
+  `ui-deferred` → no verification runs. These already declined to
+  change code (or deferred the change to the user).
 - Return with `fixer_return.suspicious == true` → no verification runs.
   `suspicious` is a boolean flag on the return, not a verdict value;
   suspicious returns carry a canned `not-addressing` verdict plus the
@@ -249,6 +264,27 @@ Per `pr-loop-lib/references/invariants.md`:
 - Return with `files_changed: []` despite verdict `fixed`: log an
   `invariant_fail` and demote to `needs-human` (the fixer claimed a
   fix but produced no diff — bug).
+
+## `ui-deferred` handling
+
+Any agent returning `ui-deferred` (after the empty-`files_changed`
+guard above passes):
+
+- Its `reply_text` is posted in step 07 but the thread is NOT
+  resolved. Step 07 uses the `ui-deferred` reply template.
+- Append an entry to `context.ui_deferred_items` with
+  `{feedback_id, thread_id?, path?, line?, author, body, proposal,
+    reply_text}`, where `proposal` is the fixer's one-line description
+  (from `fixer_return.reason`). Step 11 reads this list to prompt the
+  user for approval at the end of the run.
+- No verifier call, no sanity check entry, and no contribution to
+  `context.files_changed_this_iteration` — `ui-deferred` never edits
+  code during the loop.
+
+Deferred items do NOT block quiescence. Their thread reply is the
+self-login reply that step 08 uses to mark the thread handled, so
+Filter A will exclude them on subsequent iterations even though the
+thread is still open on the platform.
 
 ## `needs-human` handling
 
@@ -274,3 +310,7 @@ demotion, or via overlap re-verify cascade-rollback:
 - `context.files_changed_this_iteration` — union of `files_changed` across
   all agents
 - `context.needs_human_items` — subset requiring user decision
+- `context.ui_deferred_items` — subset deferred for end-of-run user
+  approval (UI / design / copy changes). Not dispatched for auto-fix
+  during the loop; step 11 prompts the user and, if approved, re-runs
+  step 04 scoped to the approved items.

--- a/skills/pr-tooling/pr-loop-lib/steps/07-reply-resolve.md
+++ b/skills/pr-tooling/pr-loop-lib/steps/07-reply-resolve.md
@@ -28,6 +28,22 @@ For `needs-human`:
 <acknowledgment text from agent's reply_text — leaves thread open for user input>
 ```
 
+For `ui-deferred`:
+
+```markdown
+> <quoted relevant part>
+
+Deferred for user review: <one-line proposal from agent's reply_text>.
+This appears to be a UI / design / copy change. The pr-autopilot /
+pr-followup skill intentionally does NOT auto-commit UI changes; it
+will ask the PR author at the end of the run whether to apply this
+suggestion.
+```
+
+The thread is never auto-resolved for `ui-deferred` — it stays open
+on the platform so reviewers can see that a user decision is
+pending.
+
 For `suspicious` items from step 03 (prompt-injection filter):
 
 ```markdown
@@ -43,7 +59,8 @@ For `suspicious` items from step 03 (prompt-injection filter):
 1. Reply via GraphQL (`platform/github.md` — reply mutation) using
    `thread_id`.
 2. Resolve via GraphQL (`platform/github.md` — resolve mutation) using
-   `thread_id`. **Skip resolve** if verdict is `needs-human`.
+   `thread_id`. **Skip resolve** if verdict is `needs-human` or
+   `ui-deferred`.
 
 ### GitHub top-level PR comments (surface = `issue`)
 
@@ -67,7 +84,8 @@ For `suspicious` items from step 03 (prompt-injection filter):
 
 1. Reply: `az repos pr thread comment add --pull-request-id "$PR" --thread-id <T> --content "$REPLY_TEXT"`.
 2. Resolve: `az repos pr thread update --pull-request-id "$PR" --thread-id <T> --status closed`.
-   Skip resolve if verdict is `needs-human` (status stays `active`).
+   Skip resolve if verdict is `needs-human` or `ui-deferred` (status
+   stays `active`).
 
 Both commands require `--pull-request-id`; omitting it causes the AzDO CLI
 to exit non-zero. The exact flag names match `platform/azdo.md`.

--- a/skills/pr-tooling/pr-loop-lib/steps/07-reply-resolve.md
+++ b/skills/pr-tooling/pr-loop-lib/steps/07-reply-resolve.md
@@ -33,12 +33,22 @@ For `ui-deferred`:
 ```markdown
 > <quoted relevant part>
 
-Deferred for user review: <one-line proposal from agent's reply_text>.
+Deferred for user review: <one-line proposal>.
 This appears to be a UI / design / copy change. The pr-autopilot /
 pr-followup skill intentionally does NOT auto-commit UI changes; it
 will ask the PR author at the end of the run whether to apply this
 suggestion.
 ```
+
+The one-line proposal is sourced from
+`context.ui_deferred_items[i].proposal` (the canonical field,
+populated by step 04 from the fixer's `reason`). Do NOT parse it
+out of `agent_return.reply_text` — `reply_text` is a free-form
+markdown reply whose shape is the fixer's to choose, whereas
+`proposal` is a single sentence the orchestrator owns. Sourcing
+from `proposal` keeps the user-facing prompt in step 11, the
+thread reply posted here, and the internal state all reading from
+one place.
 
 The thread is never auto-resolved for `ui-deferred` — it stays open
 on the platform so reviewers can see that a user decision is

--- a/skills/pr-tooling/pr-loop-lib/steps/08-quiescence-check.md
+++ b/skills/pr-tooling/pr-loop-lib/steps/08-quiescence-check.md
@@ -16,9 +16,19 @@ Decide whether to start another iteration or exit to the CI gate.
 2. **No code changed** this iteration: all verdicts are in
    `{replied, not-addressing, needs-human, ui-deferred}`. Re-entering
    the loop cannot progress — another fetch will see the same state.
-   `ui-deferred` is treated like `needs-human` for quiescence: step 07
-   posted a self-login reply, so filter A excludes the item on the
-   next fetch; the loop exits and step 11 prompts the user.
+   When this path exits AND the iteration's `context.agent_returns`
+   contains at least one entry with `verdict == "ui-deferred"`,
+   advance `context.last_handled_timestamp = now` (same mechanism as
+   the suspicious-only exit above). Filter A's pre-filter drops the
+   self-login reply step 07 posted, so the gate that actually
+   suppresses the original reviewer comment on the next fetch is the
+   "new-since" timestamp check, not the presence of a self-login
+   reply. Without this cursor advance, a subsequent `pr-followup`
+   run would re-triage the same reviewer comment, the fixer would
+   return `ui-deferred` again, and the user would be prompted twice
+   for the same item. `needs-human` iterations do not get the same
+   advance — they deliberately re-surface on the next run so the
+   user sees the still-open question in `pr-followup`'s report.
 3. **Iteration cap reached**:
    - `context.user_iteration_cap` if set → cap at that value.
    - Else 10 (default).

--- a/skills/pr-tooling/pr-loop-lib/steps/08-quiescence-check.md
+++ b/skills/pr-tooling/pr-loop-lib/steps/08-quiescence-check.md
@@ -14,8 +14,11 @@ Decide whether to start another iteration or exit to the CI gate.
    `context.last_handled_timestamp = now` so filter A's "new-since" gate
    applies to suspicious items too, and treat this iteration as quiescent.
 2. **No code changed** this iteration: all verdicts are in
-   `{replied, not-addressing, needs-human}`. Re-entering the loop cannot
-   progress — another fetch will see the same state.
+   `{replied, not-addressing, needs-human, ui-deferred}`. Re-entering
+   the loop cannot progress — another fetch will see the same state.
+   `ui-deferred` is treated like `needs-human` for quiescence: step 07
+   posted a self-login reply, so filter A excludes the item on the
+   next fetch; the loop exits and step 11 prompts the user.
 3. **Iteration cap reached**:
    - `context.user_iteration_cap` if set → cap at that value.
    - Else 10 (default).

--- a/skills/pr-tooling/pr-loop-lib/steps/11-final-report.md
+++ b/skills/pr-tooling/pr-loop-lib/steps/11-final-report.md
@@ -147,11 +147,22 @@ list is non-empty:
    override path.
 3. Run `pr-loop-lib/steps/04.5-local-verify.md` then
    `pr-loop-lib/steps/06-commit-push.md` for the resulting diff.
-   Skip steps 07 and 08 — the user has already decided; no
-   quiescence check is needed.
-4. Post a single follow-up reply per resolved thread summarizing the
-   approved change (reuses step 07's reply format; thread IS
-   resolved on success because the user explicitly approved).
+4. Re-enter `pr-loop-lib/steps/07-reply-resolve.md` with the scoped
+   `agent_returns` from the re-dispatch. Step 07 handles the
+   platform-specific reply + resolve logic uniformly: GitHub inline
+   threads resolve via the GraphQL resolve mutation, AzDO threads
+   resolve via `az repos pr thread update --status closed`, and
+   `surface: issue` comments are posted without resolve (no
+   mechanism). Because the user has explicitly approved each
+   re-dispatched item, the resulting verdicts are expected to be
+   `fixed` / `fixed-differently` / `replied` — the normal resolve
+   paths in step 07 apply. Do NOT skip the `needs-human`-style
+   resolve exception: if the re-dispatched fixer still returns
+   `needs-human` (e.g., ambiguity the override doesn't resolve),
+   the thread stays open as usual.
+5. Skip step 08 (quiescence check) — the user has already decided
+   the loop is done; re-running quiescence against the scoped list
+   would either trivially exit or spuriously re-enter the loop.
 
 ### Reject path
 
@@ -183,7 +194,8 @@ state file; a subsequent `pr-followup` invocation can re-prompt.
 
 ## Lock release
 
-As the last action before the report is printed:
+After the UI-deferred approval phase completes (no-op when the list
+is empty), and as the final action of this step:
 ```bash
 rm -rf "<repo-root>/.pr-autopilot/pr-<N>.lock"
 ```

--- a/skills/pr-tooling/pr-loop-lib/steps/11-final-report.md
+++ b/skills/pr-tooling/pr-loop-lib/steps/11-final-report.md
@@ -1,7 +1,10 @@
 # Loop step 11 — Final report
 
-Terminal step. Print a structured summary. No side effects other than
-releasing the advisory lock.
+Terminal step. Print a structured summary and — if there are UI /
+design suggestions deferred during the loop — prompt the user for
+per-item approval before releasing the advisory lock. Approved items
+are re-dispatched through step 04 (scoped) and step 06 (commit +
+push); nothing else in the loop's state is mutated.
 
 ## Report template
 
@@ -28,6 +31,7 @@ Comments addressed (<total>):
   - replied:          <n>
   - not-addressing:   <n>
   - needs-human:      <n>  (threads remain open for user input)
+  - ui-deferred:      <n>  (UI / design / copy — awaiting your approval below)
   - suspicious:       <n>  (prompt-injection filter fired)
 
 Verifier judgements (<total>):
@@ -63,6 +67,15 @@ Needs your input:
   <for each needs-human item: file:line, quoted feedback sentence,
    agent's reason>
 
+UI / design suggestions deferred to you (<total>):
+  <for each ui_deferred_items entry: file:line, author, quoted
+   feedback body (first 200 chars), fixer's one-line proposal
+   (from .proposal). Thread URL if platform supports thread-linking.>
+
+  You will be asked to approve, reject, or skip each item below. The
+  skill does NOT auto-commit UI / design / copy changes — those are
+  always a user decision.
+
 Pre-existing main-branch failures (skipped, not our responsibility):
   <per-check table if any>
 
@@ -80,6 +93,93 @@ The counts under "Internal review summary" are computed from
 The full detail (per-finding file:line, description, fixer/verifier
 outcome) lives in the review-summary file on disk — step 11 only
 prints counts to keep the terminal output scannable.
+
+## UI-deferred user-approval phase
+
+Runs after the report is printed, BEFORE lock release. Skipped
+entirely when `context.ui_deferred_items` is empty.
+
+### Prompting
+
+For each entry in `context.ui_deferred_items`, ask the user via the
+host's question mechanism (on Claude Code: `AskUserQuestion`) with
+three options:
+
+- **Apply fix and commit** — dispatch a fresh fixer for this item and
+  push the resulting change.
+- **Reject (post a polite decline)** — post a follow-up reply on the
+  thread noting the suggestion was considered and declined; do not
+  edit code.
+- **Skip (leave thread open)** — take no further action; the PR
+  author will handle it manually later.
+
+Present the item's `path:line` (when known), author, the first 200
+characters of the quoted feedback `body`, and the fixer's `proposal`
+as context in the question body so the user can decide without
+scrolling back through the report.
+
+Batch prompting is acceptable for up to 4 items in a single
+`AskUserQuestion` call (one question per item). For more than 4
+items, loop with one question at a time. Do not group distinct
+suggestions into a single multi-select — each item gets its own
+three-way decision so the user is never forced to approve a bundle.
+
+### Re-dispatch (for approved items only)
+
+Collect every item the user marked **Apply fix and commit**. If the
+list is non-empty:
+
+1. Build a synthetic `context.actionable` containing only the
+   approved items (preserve their original `id`, `surface`, `path`,
+   `line`, `body`, `thread_id`). Do NOT overwrite the prior run's
+   `actionable`; write to a scoped field
+   `context.ui_deferred_actionable` instead.
+2. Enter `pr-loop-lib/steps/04-dispatch-fixers.md` with the scoped
+   list as its input. The fixer prompt's "UI / design deferral"
+   guidance still applies, but the user's explicit approval is now
+   part of the reason the fixer should proceed with a concrete
+   change; the orchestrator passes a flag
+   `ui_deferral_override: true` through the fixer prompt's PR
+   context block (new placeholder `{{UI_DEFERRAL_OVERRIDE}}`) so
+   the fixer treats the verdict space as `fixed` /
+   `fixed-differently` / `replied` / `not-addressing` /
+   `needs-human` only — `ui-deferred` is not a valid return in the
+   override path.
+3. Run `pr-loop-lib/steps/04.5-local-verify.md` then
+   `pr-loop-lib/steps/06-commit-push.md` for the resulting diff.
+   Skip steps 07 and 08 — the user has already decided; no
+   quiescence check is needed.
+4. Post a single follow-up reply per resolved thread summarizing the
+   approved change (reuses step 07's reply format; thread IS
+   resolved on success because the user explicitly approved).
+
+### Reject path
+
+For each item the user marked **Reject**:
+
+1. Post a reply on the thread:
+   ```markdown
+   > <quoted feedback body, first 200 chars>
+
+   Considered — the PR author has decided not to apply this UI
+   change in this PR. Leaving the thread for further discussion if
+   needed.
+   ```
+2. Do NOT resolve the thread — the user rejected the code change,
+   not the conversation.
+
+### Skip path
+
+Take no action beyond what step 07 already did (the "deferred for
+user review" reply is already on the thread). The thread stays open.
+
+### Failure handling
+
+If `AskUserQuestion` is unavailable (non-interactive host, batch CI
+run), log a `ui_deferred_prompt_skipped` event with
+`{reason: "no-interactive-host", count}` and fall through to lock
+release. The ui-deferred items remain visible in the report and the
+state file; a subsequent `pr-followup` invocation can re-prompt.
 
 ## Lock release
 
@@ -103,6 +203,10 @@ which is why `rm -rf` is mandatory here.
 Per `pr-loop-lib/references/invariants.md`:
 - S11.1: `termination_reason` is set.
 - S11.2: Lock file no longer exists after this step.
+- S11.3: If `context.ui_deferred_items` is non-empty at step entry,
+  either a `ui_deferred_prompt_skipped` log event OR one
+  `ui_deferred_decision` event per item (with `decision ∈ {apply,
+  reject, skip}`) is present by step end.
 
 ## Exit
 

--- a/skills/pr-tooling/pr-loop-lib/steps/11-final-report.md
+++ b/skills/pr-tooling/pr-loop-lib/steps/11-final-report.md
@@ -4,7 +4,10 @@ Terminal step. Print a structured summary and — if there are UI /
 design suggestions deferred during the loop — prompt the user for
 per-item approval before releasing the advisory lock. Approved items
 are re-dispatched through step 04 (scoped) and step 06 (commit +
-push); nothing else in the loop's state is mutated.
+push); this may update the scoped/actionable work for those items
+along with the usual context, log, and commit/push bookkeeping for
+that re-dispatch path, but does not otherwise restart or broaden the
+loop.
 
 ## Report template
 
@@ -129,22 +132,30 @@ three-way decision so the user is never forced to approve a bundle.
 Collect every item the user marked **Apply fix and commit**. If the
 list is non-empty:
 
-1. Build a synthetic `context.actionable` containing only the
-   approved items (preserve their original `id`, `surface`, `path`,
-   `line`, `body`, `thread_id`). Do NOT overwrite the prior run's
-   `actionable`; write to a scoped field
-   `context.ui_deferred_actionable` instead.
-2. Enter `pr-loop-lib/steps/04-dispatch-fixers.md` with the scoped
-   list as its input. The fixer prompt's "UI / design deferral"
+1. Build a synthetic `context.ui_deferred_actionable` containing
+   only the approved items (preserve their original `id`,
+   `surface`, `path`, `line`, `body`, `thread_id`). Keep the
+   persisted `context.actionable` unchanged — the saved top-level
+   field must continue to reflect the loop's final triage output,
+   not the re-dispatch input.
+2. Enter `pr-loop-lib/steps/04-dispatch-fixers.md` with a **scoped
+   overlay**: for the duration of this one invocation only, step 04
+   reads its actionable list from `context.ui_deferred_actionable`
+   in place of `context.actionable`. This is an input override for
+   step 04's execution, not a mutation of the persisted top-level
+   field; on return, `context.actionable` is still the unchanged
+   list from the final loop iteration. `context.ui_deferred_actionable`
+   itself is persisted (step 11 writes it before re-dispatching)
+   so the state file is auditable, but it does not replace
+   `actionable`. The fixer prompt's "UI / design deferral"
    guidance still applies, but the user's explicit approval is now
    part of the reason the fixer should proceed with a concrete
    change; the orchestrator passes a flag
    `ui_deferral_override: true` through the fixer prompt's PR
-   context block (new placeholder `{{UI_DEFERRAL_OVERRIDE}}`) so
-   the fixer treats the verdict space as `fixed` /
-   `fixed-differently` / `replied` / `not-addressing` /
-   `needs-human` only — `ui-deferred` is not a valid return in the
-   override path.
+   context block (placeholder `{{UI_DEFERRAL_OVERRIDE}}`) so the
+   fixer treats the verdict space as `fixed` / `fixed-differently`
+   / `replied` / `not-addressing` / `needs-human` only —
+   `ui-deferred` is not a valid return in the override path.
 3. Run `pr-loop-lib/steps/04.5-local-verify.md` then
    `pr-loop-lib/steps/06-commit-push.md` for the resulting diff.
 4. Re-enter `pr-loop-lib/steps/07-reply-resolve.md` with the scoped
@@ -214,7 +225,8 @@ which is why `rm -rf` is mandatory here.
 
 Per `pr-loop-lib/references/invariants.md`:
 - S11.1: `termination_reason` is set.
-- S11.2: Lock file no longer exists after this step.
+- S11.2: Lock path (directory, per Primitive A of `state-protocol.md`)
+  no longer exists after this step.
 - S11.3: If `context.ui_deferred_items` is non-empty at step entry,
   either a `ui_deferred_prompt_skipped` log event OR one
   `ui_deferred_decision` event per item (with `decision ∈ {apply,


### PR DESCRIPTION
## Summary

Extends the pr-autopilot and pr-followup skills to defer UI/design/copy feedback to end-of-run user approval instead of auto-committing such changes. Introduces a new `ui-deferred` verdict, an interactive approval phase in step 11, and re-dispatch logic for approved items.

## Key Changes

- **New verdict type `ui-deferred`**: Fixer agents can now return this verdict for UI/design/visual/copy feedback without editing files. Defined in `fixer-prompt.md` with clear guidance on what qualifies (appearance, layout, typography, copy, UX polish).

- **Step 11 (Final Report) enhancement**: 
  - Prints count of deferred items in the report template
  - Implements interactive approval phase using `AskUserQuestion` (batched for up to 4 items)
  - Three options per item: Apply fix and commit, Reject (post polite decline), Skip (leave open)
  - Re-dispatches approved items through step 04 with `UI_DEFERRAL_OVERRIDE=true` flag, then step 06 for commit+push

- **Step 04 (Dispatch Fixers) updates**:
  - Validates that `ui-deferred` returns have empty `files_changed`; rolls back and demotes to `needs-human` if violated
  - Adds `{{UI_DEFERRAL_OVERRIDE}}` placeholder (false by default, true only during user-approved re-dispatch)
  - Collects deferred items into `context.ui_deferred_items` for step 11 prompting
  - Skips verification for `ui-deferred` verdicts (no code changed)

- **Step 07 (Reply Resolve) updates**:
  - New reply template for `ui-deferred` explaining the deferral to reviewers
  - Never auto-resolves `ui-deferred` threads (stays open for user decision)

- **Step 08 (Quiescence Check)**: Treats `ui-deferred` like `needs-human` for quiescence (loop exits, step 11 prompts user)

- **Context schema**: Adds `ui_deferred_items` array with structure `{feedback_id, thread_id?, path?, line?, author, body, proposal, reply_text}`

- **Tool permissions**: Adds `AskUserQuestion` to allowed tools in both pr-autopilot and pr-followup SKILL.md

- **Invariants & logging**: 
  - New invariant S11.3 requiring `ui_deferred_decision` events per item
  - New log events: `ui_deferred_prompt_skipped`, `ui_deferred_decision`, `ui_deferred_touched_files`
  - Handles non-interactive hosts gracefully (logs skip, state persists for later `pr-followup`)

## Implementation Details

- Approved items are re-dispatched with a scoped `context.ui_deferred_actionable` (preserves original `context.actionable`)
- Reject path posts a follow-up reply but does NOT resolve the thread
- Skip path takes no action (thread already has deferred-for-review reply from step 07)
- Fixer prompt clarifies that `ui-deferred` takes precedence over `fixed`/`replied` when applicable, and that mixed feedback (UI + logic) should split the logic portion into `fixed` while noting the UI sub-point
- Re-dispatch skips step 08 quiescence check (user has already decided loop is done)

https://claude.ai/code/session_013oUag27aiRwC2AZfBZbk3S