### PR TITLE
feat(design-coverage): wave 3 — multi-anchor, frame-granularity, action-verb template, low-confidence verdict

### DIFF
--- a/docs/superpowers/specs/2026-04-25-wave3-implementation-plan.md
+++ b/docs/superpowers/specs/2026-04-25-wave3-implementation-plan.md
@@ -65,12 +65,12 @@ flows into `get_sealed_enum_pattern_keys()` automatically — no other wiring re
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["frame_id", "name", "is_leaf", "parent_id"],
+        "required": ["frame_id", "name", "is_leaf", "figma_parent_id"],
         "properties": {
-          "frame_id":  { "type": "string",          "minLength": 1 },
-          "name":      { "type": "string",          "minLength": 1 },
-          "is_leaf":   { "type": "boolean"                        },
-          "parent_id": { "type": ["string", "null"]               }
+          "frame_id":        { "type": "string",          "minLength": 1 },
+          "name":            { "type": "string",          "minLength": 1 },
+          "is_leaf":         { "type": "boolean"                        },
+          "figma_parent_id": { "type": ["string", "null"]               }
         }
       }
     }
@@ -142,8 +142,20 @@ writing `01-flow-mapping.json`.
 1. Read `multi_anchor_suffixes` from the resolved platform-hint frontmatter
    (already available via `hint_frontmatter.parse_hint_frontmatter`).
    Default to `[]` if the field is absent (hint has no ambiguous-suffix pairs).
-2. Strip each known suffix from the end of every candidate class name to derive
-   a base name. Group candidates by their base name.
+2. For each candidate class name, strip the first suffix in `multi_anchor_suffixes`
+   that matches its end, yielding a base name. If no suffix matches, the class name
+   itself is the base name. Group all candidates by base name.
+   - Example: `multi_anchor_suffixes = ["ViewController", "HostingController"]`
+     - `AppointmentDetailsViewController` → base `AppointmentDetails`
+     - `AppointmentDetailsHostingController` → base `AppointmentDetails`
+     - Both map to the same group → ambiguous pair.
+   - The spec's narrative example (`MBOApptDetailViewController` vs
+     `AppointmentDetailsHostingController`) yields different bases (`MBOApptDetail`
+     and `AppointmentDetails`) and would **not** trigger disambiguation — those are
+     genuinely different classes that happen to both match the Figma frame name. The
+     algorithm is intentionally conservative: it only flags classes that are clearly
+     platform-variant rewrites of the same screen (same base, different framework
+     suffix), not all multi-match candidates.
 3. If **any group contains N ≥ 2 candidates** that share the same base name →
    **refuse-loud** (interactive in-session, never a file handoff). Present **all
    N candidates in a single question** (not one question per pair):
@@ -227,10 +239,10 @@ Before the per-frame loop, emit:
 frame_classification = {
     "frames": [
         {
-            "frame_id": f["id"],
-            "name":     f["name"],
-            "is_leaf":  <bool>,
-            "parent_id": f.get("parentId")  # Figma parent, not pipeline parent_id
+            "frame_id":        f["id"],
+            "name":            f["name"],
+            "is_leaf":         <bool>,
+            "figma_parent_id": f.get("parentId")  # Figma node parent ID
         }
         for f in all_in_scope_frames
     ]
@@ -348,6 +360,11 @@ Tests the multi-anchor detection algorithm described in stage 01.
 - `input/AppointmentDetailsViewController.swift` — contains `class AppointmentDetailsViewController`
 - `input/AppointmentDetailsHostingController.swift` — contains `class AppointmentDetailsHostingController`
 - `hint_suffixes.json` — `["ViewController", "HostingController"]`
+
+Both classes strip to base `AppointmentDetails`, which satisfies the suffix-based
+disambiguation criterion. (The spec's narrative example — `MBOApptDetailViewController`
+vs `AppointmentDetailsHostingController` — strips to different bases and is explicitly
+not caught by this algorithm; see algorithm note in section 5.)
 
 **Tests:**
 1. `test_multi_anchor_detected` — given two candidates whose base names match after

--- a/docs/superpowers/specs/2026-04-25-wave3-implementation-plan.md
+++ b/docs/superpowers/specs/2026-04-25-wave3-implementation-plan.md
@@ -1,0 +1,389 @@
+# Wave 3 — Implementation Plan (issue #13)
+
+This document is the agent-facing implementation plan for Wave 3 of the
+design-coverage improvements. It precedes code changes; all items below
+require review approval before implementation begins.
+
+Reference spec: `docs/superpowers/specs/2026-04-25-design-coverage-improvements-design.md`
+Feature branch: `claude/issue-13-implementation-DwefJ`
+
+---
+
+## Scope
+
+Wave 3 covers four improvements:
+
+| ID  | Title                          |
+|-----|-------------------------------|
+| #4  | Multi-anchor disambiguation    |
+| #5  | Frame-granularity policy       |
+| #12 | Next-5-actions template        |
+| #13 | Low-confidence verdict warning |
+
+---
+
+## Pre-conditions
+
+- `multi_anchor_suffixes` frontmatter field is already defined in
+  `lib/hint_frontmatter.py` (landed with wave 2 on `pratyush/design-coverage-wave-2`,
+  already merged into `main`).
+- `sealed_enum_index.get_sealed_enum_pattern_keys()` auto-derives keys from schemas,
+  so adding `"screen-group"` to `inventory_item.json` will flow through automatically.
+
+---
+
+## Change-by-change breakdown
+
+### 1. `schemas/inventory_item.json` — add `"screen-group"` to `kind` enum
+
+**Why:** #5 requires section-level frame groupings to emit as a distinct kind.
+
+**What changes:**
+```diff
+-"enum": ["screen", "state", "action", "field"]
++"enum": ["screen", "screen-group", "state", "action", "field"]
+```
+
+`x-platform-pattern: true` is already set on `kind`, so `inventory_item.kind.screen-group`
+flows into `get_sealed_enum_pattern_keys()` automatically — no other wiring required.
+
+---
+
+### 2. `schemas/frame_classification.json` (NEW)
+
+**Why:** #5 promotes `_in_scope_with_names.json` (scratch) to a real pipeline artifact
+`00-frame-classification.json` with a validated schema.
+
+**Shape:**
+```json
+{
+  "$id": "frame_classification.json",
+  "type": "object",
+  "required": ["frames"],
+  "properties": {
+    "frames": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["frame_id", "name", "is_leaf", "parent_id"],
+        "properties": {
+          "frame_id":  { "type": "string",          "minLength": 1 },
+          "name":      { "type": "string",          "minLength": 1 },
+          "is_leaf":   { "type": "boolean"                        },
+          "parent_id": { "type": ["string", "null"]               }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+### 3. `lib/action_verbs.py` (NEW)
+
+**Why:** #12 requires a constrained verb list and a slot-fill template so two runs on
+the same data produce matching action verbs and noun-objects.
+
+**Contents:**
+```python
+ALLOWED_VERBS = ["Ask", "Confirm", "Drop", "Document", "Wire", "Deprecate"]
+
+ACTION_TEMPLATE = (
+    "{N}. **{verb} {object}** — {legacy_ref} {has no | conflicts with} {figma_ref}.\n"
+    "   {one-sentence consequence}. Action: "
+    "{ask_design | confirm_with_product | document_as_dropped | wire_in_navigation}."
+)
+```
+
+No logic beyond the constant exports — just the vocabulary contract.
+
+---
+
+### 4. `schemas/clarifications.json` — add `figma_dedup_policy` field
+
+**Why:** Stage 03's new `figma_dedup_policy` Q (for #5) needs a home in the schema.
+Adding it as a top-level field (not a hotspot `resolved[]` entry) because it is a
+global Figma-inventory policy, not a per-hotspot decision.
+
+**What changes:**
+```diff
+ "properties": {
+   "resolved": { ... },
+-  "in_scope_destinations": { ... }
++  "in_scope_destinations": { ... },
++  "figma_dedup_policy": {
++    "type": "string",
++    "enum": ["none", "dark-twins-folded", "appearance-modes-folded"]
++  }
+ }
+```
+
+---
+
+### 5. `stages/01-flow-locator.md` — multi-anchor disambiguation (#4)
+
+**Where it fits:** After the candidate-class grep loop (Pass 1 and Pass 2), before
+writing `01-flow-mapping.json`.
+
+**Algorithm to document:**
+1. Read `multi_anchor_suffixes` from the resolved platform-hint frontmatter
+   (already available via `hint_frontmatter.parse_hint_frontmatter`).
+   Default to `[]` if the field is absent (hint has no ambiguous-suffix pairs).
+2. Strip each known suffix from the end of every candidate class name; compare
+   the resulting base names pairwise.
+3. If any two candidates share the same base name → **refuse-loud** (interactive
+   in-session, never a file handoff):
+
+   > "Found multiple anchors for Figma frame `<name>`:\n
+   >  - `<CandidateA>` (`<file>`, last modified `<date>`, `<N>` lines)\n
+   >  - `<CandidateB>` (`<file>`, last modified `<date>`, `<N>` lines)\n\n
+   > Which should anchor the audit?"
+
+   Ask via the live `AskUserQuestion` interface with each candidate as a choice.
+4. Record the user's selection in `00-run-config.json`:
+   ```json
+   "selected_anchor": "<chosen class name>",
+   "selected_anchor_reason": "user-picked-multi-anchor"
+   ```
+5. Continue stage 01 using only the selected anchor.
+
+**Run-config schema note:** The `00-run-config.json` is written by the orchestrator
+(SKILL.md), not validated against `schemas/run.json` (which is the stages-status
+schema). No schema change is required — `selected_anchor` and `selected_anchor_reason`
+are additive fields on the open-shape run-config object.
+
+---
+
+### 6. `stages/03-clarification.md` — `figma_dedup_policy` Q (#5)
+
+**Where it fits:** After hotspot questions and candidate-destination scope, before
+writing `03-clarifications.json`.
+
+**New question to emit:**
+> "How should Figma appearance variants (light/dark mode, etc.) be handled in the
+> inventory?
+>  - `none` — keep all variants as separate inventory items
+>  - `dark-twins-folded` *(default)* — fold light/dark pairs into one item with
+>    `modes: ["light", "dark"]`
+>  - `appearance-modes-folded` — fold all appearance variants (including dynamic
+>    type, high-contrast) into one item"
+
+Persist the answer in `03-clarifications.json` as:
+```json
+"figma_dedup_policy": "dark-twins-folded"
+```
+
+**Short-circuit update:** The existing short-circuit ("If both lists are empty,
+write and exit") is updated to also write `figma_dedup_policy` with the default
+`"dark-twins-folded"` when the user is not asked — so stage 04 always has the
+field available.
+
+---
+
+### 7. `stages/04-figma-inventory.md` — leaf-frame level + screen-group + frame-classification (#5)
+
+Three coordinated changes:
+
+#### 7a — Pin granularity to leaf-frame level
+
+A **leaf frame** = `type == "FRAME"` AND has no direct `FRAME`-type children.
+
+For each in-scope Figma file:
+1. Identify all frames with `type == FRAME`.
+2. Classify each: if it has no `FRAME` children → `is_leaf: true`; else → `is_leaf: false`.
+3. **Only** process leaf frames through the full per-frame procedure (MCP call,
+   screenshot, InventoryItem generation).
+4. Emit section-level (non-leaf) frames as `kind: "screen-group"` InventoryItems
+   with `parent_id: null` — no MCP call needed, just the frame metadata.
+
+#### 7b — Emit `00-frame-classification.json` as a real artifact
+
+Before the per-frame loop, emit:
+```python
+frame_classification = {
+    "frames": [
+        {
+            "frame_id": f["id"],
+            "name":     f["name"],
+            "is_leaf":  <bool>,
+            "parent_id": f.get("parentId")  # Figma parent, not pipeline parent_id
+        }
+        for f in all_in_scope_frames
+    ]
+}
+validate_and_write_json(
+    run_dir / "00-frame-classification.json",
+    frame_classification,
+    "frame_classification.json",
+    get_skill_root() / "schemas",
+)
+```
+
+This replaces the old `<run_dir>/.scratch/_in_scope_with_names.json` pattern.
+
+#### 7c — Honor `figma_dedup_policy`
+
+Read `03-clarifications.json`'s `figma_dedup_policy` (default `"dark-twins-folded"`
+if field absent for backward compatibility). Apply folding:
+- `"none"` → emit every variant as its own InventoryItem.
+- `"dark-twins-folded"` → when two leaf frames share the same logical name and differ
+  only by a light/dark appearance suffix (e.g., `Appt Details – Light` /
+  `Appt Details – Dark`), emit one item with `modes: ["light", "dark"]`.
+- `"appearance-modes-folded"` → fold all appearance-variant twins into one item;
+  populate `modes` with all detected variant labels.
+
+---
+
+### 8. `SKILL.md` — slot-fill template + low-confidence warning (#12, #13)
+
+#### 8a — Low-confidence verdict warning (#13)
+
+In "Final output" § "Required structure" item 2, replace:
+
+> `> **Verdict:** 🟢 Ready to ship`
+
+with a conditional:
+
+> Read `<run-dir>/01-flow-mapping.json`. If `confidence == "low"` OR
+> `locator_method == "name-search"`, prepend the verdict block with:
+>
+> ```
+> > ⚠ **Low-confidence anchor — review stage 1 before trusting this report.**
+> > **Verdict:** 🟢 Ready to ship
+> ```
+>
+> Otherwise emit the verdict line without the warning.
+
+#### 8b — Next-5-actions slot-fill template (#12)
+
+In "Required structure" item 3 ("Next 5 actions"), replace the free-prose instruction:
+
+> "One sentence each, imperative voice, beginning with a verb ("Ask design to add…", …)"
+
+with the constrained template:
+
+> Verb **must** be one of `ALLOWED_VERBS` from `lib/action_verbs.py`:
+> `Ask | Confirm | Drop | Document | Wire | Deprecate`.
+>
+> Each action uses this slot-fill template:
+> ```
+> {N}. **{verb} {object}** — {legacy_ref} {has no | conflicts with} {figma_ref}.
+>    {one-sentence consequence}. Action: {ask_design | confirm_with_product | document_as_dropped | wire_in_navigation}.
+> ```
+>
+> Fill every slot. Do not write free-form prose in place of the template.
+
+---
+
+### 9. `stages/06-report-generator.md` — cross-reference (#12, #13)
+
+Add a short reference section to the "Narrative summary (NOT this stage)" block
+noting that:
+- The narrative render reads `01-flow-mapping.json.confidence` and `.locator_method`
+  to decide whether to prepend the low-confidence warning (see SKILL.md § "Final output").
+- The "Next 5 actions" block in the narrative is constrained by `lib/action_verbs.py`'s
+  `ALLOWED_VERBS` and slot-fill template (see SKILL.md § "Final output").
+
+No logic changes to this file — purely cross-reference prose so an agent reading
+stage 06 in isolation knows where to look.
+
+---
+
+## Tests to add
+
+All tests go under `skill-tests/design-coverage/tests/`.
+
+### `test_multi_anchor_disambiguate.py`
+
+Tests the multi-anchor detection algorithm described in stage 01.
+
+**Fixtures needed** (`skill-tests/design-coverage/fixtures/stage-01/multi-anchor/`):
+- `input/AppointmentDetailsViewController.swift` — contains `class AppointmentDetailsViewController`
+- `input/AppointmentDetailsHostingController.swift` — contains `class AppointmentDetailsHostingController`
+- `hint_suffixes.json` — `["ViewController", "HostingController"]`
+
+**Tests:**
+1. `test_multi_anchor_detected` — given two candidates whose base names match after
+   stripping suffixes, `detect_multi_anchor_pair(candidates, suffixes)` returns the
+   pair.
+2. `test_single_anchor_not_flagged` — one candidate never triggers disambiguation.
+3. `test_no_suffix_match_not_flagged` — two candidates with different base names after
+   stripping are not flagged.
+4. `test_run_config_records_selected_anchor` — the run-config dict gains
+   `selected_anchor` and `selected_anchor_reason: "user-picked-multi-anchor"` when a
+   selection is made.
+
+### `test_frame_classification_schema.py`
+
+Tests that `schemas/frame_classification.json` is well-formed and validates correct
+and incorrect payloads.
+
+**Fixtures needed** (`skill-tests/design-coverage/fixtures/frame-classification/`):
+- `valid_leaf_only.json` — two leaf frames, `parent_id: null`
+- `valid_mixed.json` — one parent frame (`is_leaf: false`) + two leaf children
+- `invalid_missing_is_leaf.json` — frame item missing `is_leaf` field
+
+**Tests:**
+1. `test_schema_file_exists` — `schemas/frame_classification.json` is present and
+   parses as valid JSON.
+2. `test_valid_leaf_only_passes` — fixture validates against schema.
+3. `test_valid_mixed_passes` — mixed parent+leaf fixture validates.
+4. `test_missing_is_leaf_fails` — invalid fixture raises `ValidationError`.
+
+### `test_action_verbs.py`
+
+Tests `lib/action_verbs.py`.
+
+**Tests:**
+1. `test_allowed_verbs_exported` — `ALLOWED_VERBS` exists and equals
+   `["Ask", "Confirm", "Drop", "Document", "Wire", "Deprecate"]`.
+2. `test_action_template_exported` — `ACTION_TEMPLATE` exists and is a non-empty string.
+3. `test_template_contains_verb_slot` — `ACTION_TEMPLATE` contains `{verb}`.
+4. `test_template_contains_object_slot` — `ACTION_TEMPLATE` contains `{object}`.
+
+### `test_low_confidence_verdict.py`
+
+Tests the low-confidence verdict prepend logic described in SKILL.md.
+
+**Tests:**
+1. `test_low_confidence_triggers_warning` — a flow-mapping with `confidence: "low"` +
+   any `locator_method` produces a warning-prepended verdict block.
+2. `test_name_search_triggers_warning` — `locator_method: "name-search"` (regardless
+   of `confidence`) produces a warning-prepended verdict block.
+3. `test_high_confidence_nav_graph_no_warning` — `confidence: "high"` +
+   `locator_method: "nav-graph"` produces a clean verdict with no warning.
+4. `test_warning_block_contains_expected_text` — the warning block contains
+   `⚠` and `Low-confidence anchor`.
+
+---
+
+## Unchanged files
+
+The following files are **not touched** by Wave 3:
+
+- `stages/02-code-inventory.md`
+- `stages/05-comparator.md`
+- `schemas/comparison.json`, `schemas/code_inventory.json`, `schemas/figma_inventory.json`,
+  `schemas/flow_mapping.json`, `schemas/report.json`, `schemas/run.json`
+- All `lib/` files except the new `lib/action_verbs.py`
+- `design-coverage-scout/` — untouched by wave 3
+
+---
+
+## Execution order
+
+1. `schemas/inventory_item.json` — add `screen-group` (unblocks sealed-enum derivation)
+2. `schemas/frame_classification.json` — new schema
+3. `schemas/clarifications.json` — add `figma_dedup_policy`
+4. `lib/action_verbs.py` — new file
+5. `stages/01-flow-locator.md` — multi-anchor section
+6. `stages/03-clarification.md` — `figma_dedup_policy` Q
+7. `stages/04-figma-inventory.md` — leaf-frame level + screen-group + classification artifact
+8. `SKILL.md` — verdict warning + slot-fill template
+9. `stages/06-report-generator.md` — cross-references
+10. Tests + fixtures
+
+Each step is independently reviewable; no step creates a compile/import dependency on
+a later step (the stage `.md` files are prose, not executable code, so order matters
+only for logical completeness).

--- a/docs/superpowers/specs/2026-04-25-wave3-implementation-plan.md
+++ b/docs/superpowers/specs/2026-04-25-wave3-implementation-plan.md
@@ -1,8 +1,9 @@
 # Wave 3 — Implementation Plan (issue #13)
 
 This document is the agent-facing implementation plan for Wave 3 of the
-design-coverage improvements. It precedes code changes; all items below
-require review approval before implementation begins.
+design-coverage improvements. The PR that introduced this doc also contains the
+full implementation; the plan serves as a design reference and audit trail for
+what was built and why.
 
 Reference spec: `docs/superpowers/specs/2026-04-25-design-coverage-improvements-design.md`
 Feature branch: `claude/issue-13-implementation-DwefJ`
@@ -106,7 +107,9 @@ are invalid `str.format()` placeholder names; calling `.format()` on it would ra
 the appropriate choice inline — it does not call `.format()`.
 
 `test_action_verbs.py` verifies the exported names and checks that `"{verb}"` and
-`"{object}"` are present in the display string; it does NOT attempt `.format()`.
+`"{object}"` are present in the display string; it also calls `.format()` (with no
+arguments) and asserts `KeyError` is raised — making the "not a format target"
+contract machine-checked.
 
 No logic beyond the constant exports — just the vocabulary contract.
 
@@ -342,7 +345,7 @@ default value. The expected fixture at
 `skill-tests/design-coverage/fixtures/stage-03/zero-hotspots/expected/clarifications.json`
 is currently `{"resolved": []}` — it must be updated to:
 ```json
-{"resolved": [], "figma_dedup_policy": "dark-twins-folded"}
+{"resolved": [], "in_scope_destinations": [], "figma_dedup_policy": "dark-twins-folded"}
 ```
 `test_stage3_zero_hotspots.py` must be updated accordingly.
 

--- a/docs/superpowers/specs/2026-04-25-wave3-implementation-plan.md
+++ b/docs/superpowers/specs/2026-04-25-wave3-implementation-plan.md
@@ -89,12 +89,24 @@ the same data produce matching action verbs and noun-objects.
 ```python
 ALLOWED_VERBS = ["Ask", "Confirm", "Drop", "Document", "Wire", "Deprecate"]
 
-ACTION_TEMPLATE = (
+# Display guide for agent use — NOT a str.format() template.
+# Slots with `|`-delimited options (e.g., `{has no | conflicts with}`) are
+# prose choices; the agent picks one. Do NOT call .format() on this string.
+ACTION_TEMPLATE_DISPLAY = (
     "{N}. **{verb} {object}** — {legacy_ref} {has no | conflicts with} {figma_ref}.\n"
     "   {one-sentence consequence}. Action: "
     "{ask_design | confirm_with_product | document_as_dropped | wire_in_navigation}."
 )
 ```
+
+`ACTION_TEMPLATE_DISPLAY` is a prose guide for the agent, not a callable Python
+format string. Slots like `{has no | conflicts with}` contain spaces and pipes that
+are invalid `str.format()` placeholder names; calling `.format()` on it would raise
+`KeyError`. The agent reads the template as guidance and fills each slot by writing
+the appropriate choice inline — it does not call `.format()`.
+
+`test_action_verbs.py` verifies the exported names and checks that `"{verb}"` and
+`"{object}"` are present in the display string; it does NOT attempt `.format()`.
 
 No logic beyond the constant exports — just the vocabulary contract.
 
@@ -130,17 +142,21 @@ writing `01-flow-mapping.json`.
 1. Read `multi_anchor_suffixes` from the resolved platform-hint frontmatter
    (already available via `hint_frontmatter.parse_hint_frontmatter`).
    Default to `[]` if the field is absent (hint has no ambiguous-suffix pairs).
-2. Strip each known suffix from the end of every candidate class name; compare
-   the resulting base names pairwise.
-3. If any two candidates share the same base name → **refuse-loud** (interactive
-   in-session, never a file handoff):
+2. Strip each known suffix from the end of every candidate class name to derive
+   a base name. Group candidates by their base name.
+3. If **any group contains N ≥ 2 candidates** that share the same base name →
+   **refuse-loud** (interactive in-session, never a file handoff). Present **all
+   N candidates in a single question** (not one question per pair):
 
    > "Found multiple anchors for Figma frame `<name>`:\n
-   >  - `<CandidateA>` (`<file>`, last modified `<date>`, `<N>` lines)\n
-   >  - `<CandidateB>` (`<file>`, last modified `<date>`, `<N>` lines)\n\n
+   >  - `<Candidate1>` (`<file>`, last modified `<date>`, `<N>` lines)\n
+   >  - `<Candidate2>` (`<file>`, last modified `<date>`, `<N>` lines)\n
+   >  - `<CandidateN>` (`<file>`, last modified `<date>`, `<N>` lines)\n\n
    > Which should anchor the audit?"
 
    Ask via the live `AskUserQuestion` interface with each candidate as a choice.
+   If multiple groups each have N ≥ 2 ambiguous candidates, ask one question per
+   group in sequence.
 4. Record the user's selection in `00-run-config.json`:
    ```json
    "selected_anchor": "<chosen class name>",
@@ -198,6 +214,13 @@ For each in-scope Figma file:
    with `parent_id: null` — no MCP call needed, just the frame metadata.
 
 #### 7b — Emit `00-frame-classification.json` as a real artifact
+
+**Resumability:** `00-frame-classification.json` is written **unconditionally** (before
+the per-frame loop, on every invocation including resumes). The classification is
+deterministic — the same Figma structure always produces the same output — so
+re-writing on resume is safe. Do NOT add a guard that skips the write when the file
+already exists; that would leave a resumed run without the artifact if it was absent
+for any reason.
 
 Before the per-frame loop, emit:
 ```python
@@ -290,6 +313,29 @@ stage 06 in isolation knows where to look.
 
 ---
 
+## Existing tests to update
+
+### `test_schemas_parse.py` — bump schema count 8 → 9
+
+`skill-tests/design-coverage/tests/test_schemas_parse.py` line 9 currently asserts:
+```python
+assert len(files) == 8, f"expected 8 schemas, found {len(files)}"
+```
+Adding `schemas/frame_classification.json` makes the count 9. Update to `== 9`.
+
+### `test_stage3_zero_hotspots.py` and its fixture
+
+The zero-hotspot short-circuit in stage 03 now writes `figma_dedup_policy` with the
+default value. The expected fixture at
+`skill-tests/design-coverage/fixtures/stage-03/zero-hotspots/expected/clarifications.json`
+is currently `{"resolved": []}` — it must be updated to:
+```json
+{"resolved": [], "figma_dedup_policy": "dark-twins-folded"}
+```
+`test_stage3_zero_hotspots.py` must be updated accordingly.
+
+---
+
 ## Tests to add
 
 All tests go under `skill-tests/design-coverage/tests/`.
@@ -338,9 +384,12 @@ Tests `lib/action_verbs.py`.
 **Tests:**
 1. `test_allowed_verbs_exported` — `ALLOWED_VERBS` exists and equals
    `["Ask", "Confirm", "Drop", "Document", "Wire", "Deprecate"]`.
-2. `test_action_template_exported` — `ACTION_TEMPLATE` exists and is a non-empty string.
-3. `test_template_contains_verb_slot` — `ACTION_TEMPLATE` contains `{verb}`.
-4. `test_template_contains_object_slot` — `ACTION_TEMPLATE` contains `{object}`.
+2. `test_action_template_display_exported` — `ACTION_TEMPLATE_DISPLAY` exists and is a
+   non-empty string.
+3. `test_template_contains_verb_slot` — `ACTION_TEMPLATE_DISPLAY` contains `{verb}`.
+4. `test_template_contains_object_slot` — `ACTION_TEMPLATE_DISPLAY` contains `{object}`.
+5. `test_template_is_not_format_callable` — calling `ACTION_TEMPLATE_DISPLAY.format()`
+   raises `KeyError` (documents that it is intentionally not a `str.format()` target).
 
 ### `test_low_confidence_verdict.py`
 
@@ -382,7 +431,9 @@ The following files are **not touched** by Wave 3:
 7. `stages/04-figma-inventory.md` — leaf-frame level + screen-group + classification artifact
 8. `SKILL.md` — verdict warning + slot-fill template
 9. `stages/06-report-generator.md` — cross-references
-10. Tests + fixtures
+10. `test_schemas_parse.py` — bump count 8 → 9 (must not be forgotten; breaks CI otherwise)
+11. `fixtures/stage-03/zero-hotspots/expected/clarifications.json` + `test_stage3_zero_hotspots.py` — add `figma_dedup_policy`
+12. New test files + fixtures (`test_multi_anchor_disambiguate.py`, `test_frame_classification_schema.py`, `test_action_verbs.py`, `test_low_confidence_verdict.py`)
 
 Each step is independently reviewable; no step creates a compile/import dependency on
 a later step (the stage `.md` files are prose, not executable code, so order matters

--- a/skill-tests/design-coverage/fixtures/frame-classification/invalid_missing_is_leaf.json
+++ b/skill-tests/design-coverage/fixtures/frame-classification/invalid_missing_is_leaf.json
@@ -1,0 +1,5 @@
+{
+  "frames": [
+    {"frame_id": "3:1", "name": "Appointment Details", "figma_parent_id": null}
+  ]
+}

--- a/skill-tests/design-coverage/fixtures/frame-classification/valid_leaf_only.json
+++ b/skill-tests/design-coverage/fixtures/frame-classification/valid_leaf_only.json
@@ -1,0 +1,6 @@
+{
+  "frames": [
+    {"frame_id": "1:1", "name": "Appointment Details", "is_leaf": true, "figma_parent_id": null},
+    {"frame_id": "1:2", "name": "Client Profile",      "is_leaf": true, "figma_parent_id": null}
+  ]
+}

--- a/skill-tests/design-coverage/fixtures/frame-classification/valid_mixed.json
+++ b/skill-tests/design-coverage/fixtures/frame-classification/valid_mixed.json
@@ -1,0 +1,7 @@
+{
+  "frames": [
+    {"frame_id": "2:1", "name": "Scheduling",              "is_leaf": false, "figma_parent_id": null},
+    {"frame_id": "2:2", "name": "Appointment Details",     "is_leaf": true,  "figma_parent_id": "2:1"},
+    {"frame_id": "2:3", "name": "Appointment Confirmation","is_leaf": true,  "figma_parent_id": "2:1"}
+  ]
+}

--- a/skill-tests/design-coverage/fixtures/stage-01/multi-anchor/input/AppointmentDetailsHostingController.swift
+++ b/skill-tests/design-coverage/fixtures/stage-01/multi-anchor/input/AppointmentDetailsHostingController.swift
@@ -1,0 +1,6 @@
+// SwiftUI hosting controller for the appointment details screen.
+class AppointmentDetailsHostingController: UIHostingController<AppointmentDetailsView> {
+    required init?(coder: NSCoder) {
+        super.init(coder: coder, rootView: AppointmentDetailsView())
+    }
+}

--- a/skill-tests/design-coverage/fixtures/stage-01/multi-anchor/input/AppointmentDetailsViewController.swift
+++ b/skill-tests/design-coverage/fixtures/stage-01/multi-anchor/input/AppointmentDetailsViewController.swift
@@ -1,0 +1,6 @@
+// Legacy UIKit view controller for the appointment details screen.
+class AppointmentDetailsViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/skill-tests/design-coverage/fixtures/stage-01/multi-anchor/input/hint_suffixes.json
+++ b/skill-tests/design-coverage/fixtures/stage-01/multi-anchor/input/hint_suffixes.json
@@ -1,0 +1,1 @@
+["ViewController", "HostingController"]

--- a/skill-tests/design-coverage/fixtures/stage-03/zero-hotspots/expected/clarifications.json
+++ b/skill-tests/design-coverage/fixtures/stage-03/zero-hotspots/expected/clarifications.json
@@ -1,1 +1,1 @@
-{"resolved": []}
+{"resolved": [], "in_scope_destinations": [], "figma_dedup_policy": "dark-twins-folded"}

--- a/skill-tests/design-coverage/tests/test_action_verbs.py
+++ b/skill-tests/design-coverage/tests/test_action_verbs.py
@@ -1,0 +1,40 @@
+"""Tests for lib/action_verbs.py (wave 3 #12)."""
+from __future__ import annotations
+
+import pytest
+from action_verbs import ALLOWED_VERBS, ACTION_TEMPLATE_DISPLAY
+
+
+def test_allowed_verbs_exported():
+    assert ALLOWED_VERBS == ["Ask", "Confirm", "Drop", "Document", "Wire", "Deprecate"]
+
+
+def test_action_template_display_exported():
+    assert isinstance(ACTION_TEMPLATE_DISPLAY, str)
+    assert len(ACTION_TEMPLATE_DISPLAY) > 0
+
+
+def test_template_contains_verb_slot():
+    assert "{verb}" in ACTION_TEMPLATE_DISPLAY
+
+
+def test_template_contains_object_slot():
+    assert "{object}" in ACTION_TEMPLATE_DISPLAY
+
+
+def test_template_is_not_format_callable():
+    """ACTION_TEMPLATE_DISPLAY is a prose display guide, not a str.format() target.
+    Slots like `{has no | conflicts with}` are invalid placeholder names — calling
+    .format() must raise KeyError so the contract is machine-checked."""
+    with pytest.raises(KeyError):
+        ACTION_TEMPLATE_DISPLAY.format()
+
+
+def test_all_allowed_verbs_are_title_case():
+    for verb in ALLOWED_VERBS:
+        assert verb[0].isupper(), f"{verb!r} must start with an uppercase letter"
+        assert verb == verb.strip(), f"{verb!r} must not have surrounding whitespace"
+
+
+def test_allowed_verbs_no_duplicates():
+    assert len(ALLOWED_VERBS) == len(set(ALLOWED_VERBS))

--- a/skill-tests/design-coverage/tests/test_frame_classification_schema.py
+++ b/skill-tests/design-coverage/tests/test_frame_classification_schema.py
@@ -5,7 +5,7 @@ import json
 import os
 import pytest
 from pathlib import Path
-from validator import Validator, ValidationError
+from validator import ValidationError, Validator
 
 SCHEMAS = Path(os.environ["DESIGN_COVERAGE_SKILL_ROOT"]) / "schemas"
 FIXTURES = Path(__file__).parents[1] / "fixtures" / "frame-classification"
@@ -32,7 +32,7 @@ def test_valid_mixed_passes():
 def test_missing_is_leaf_fails():
     data = json.loads((FIXTURES / "invalid_missing_is_leaf.json").read_text())
     schema = json.loads((SCHEMAS / "frame_classification.json").read_text())
-    with pytest.raises((ValidationError, Exception)):
+    with pytest.raises(ValidationError):
         Validator(SCHEMAS).validate(data, schema)
 
 

--- a/skill-tests/design-coverage/tests/test_frame_classification_schema.py
+++ b/skill-tests/design-coverage/tests/test_frame_classification_schema.py
@@ -1,0 +1,54 @@
+"""Tests for schemas/frame_classification.json (wave 3 #5)."""
+from __future__ import annotations
+
+import json
+import os
+import pytest
+from pathlib import Path
+from validator import Validator, ValidationError
+
+SCHEMAS = Path(os.environ["DESIGN_COVERAGE_SKILL_ROOT"]) / "schemas"
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "frame-classification"
+
+
+def test_schema_file_exists():
+    schema_path = SCHEMAS / "frame_classification.json"
+    assert schema_path.exists(), "schemas/frame_classification.json is missing"
+    json.loads(schema_path.read_text())  # must parse as valid JSON
+
+
+def test_valid_leaf_only_passes():
+    data = json.loads((FIXTURES / "valid_leaf_only.json").read_text())
+    schema = json.loads((SCHEMAS / "frame_classification.json").read_text())
+    Validator(SCHEMAS).validate(data, schema)  # must not raise
+
+
+def test_valid_mixed_passes():
+    data = json.loads((FIXTURES / "valid_mixed.json").read_text())
+    schema = json.loads((SCHEMAS / "frame_classification.json").read_text())
+    Validator(SCHEMAS).validate(data, schema)  # must not raise
+
+
+def test_missing_is_leaf_fails():
+    data = json.loads((FIXTURES / "invalid_missing_is_leaf.json").read_text())
+    schema = json.loads((SCHEMAS / "frame_classification.json").read_text())
+    with pytest.raises((ValidationError, Exception)):
+        Validator(SCHEMAS).validate(data, schema)
+
+
+def test_leaf_frame_is_leaf_true():
+    data = json.loads((FIXTURES / "valid_leaf_only.json").read_text())
+    for frame in data["frames"]:
+        assert frame["is_leaf"] is True
+
+
+def test_parent_frame_is_leaf_false():
+    data = json.loads((FIXTURES / "valid_mixed.json").read_text())
+    parent = next(f for f in data["frames"] if f["frame_id"] == "2:1")
+    assert parent["is_leaf"] is False
+
+
+def test_figma_parent_id_nullable():
+    data = json.loads((FIXTURES / "valid_leaf_only.json").read_text())
+    for frame in data["frames"]:
+        assert frame["figma_parent_id"] is None

--- a/skill-tests/design-coverage/tests/test_low_confidence_verdict.py
+++ b/skill-tests/design-coverage/tests/test_low_confidence_verdict.py
@@ -1,0 +1,77 @@
+"""Tests for the low-confidence anchor verdict warning (wave 3 #13).
+
+The narrative render in SKILL.md reads 01-flow-mapping.json and prepends a
+warning block when confidence == "low" OR locator_method == "name-search".
+"""
+from __future__ import annotations
+
+WARNING_PREFIX = "> ⚠ **Low-confidence anchor — review stage 1 before trusting this report.**"
+
+
+def should_warn(flow_mapping: dict) -> bool:
+    """Return True if the verdict block should be prepended with the warning."""
+    return (
+        flow_mapping.get("confidence") == "low"
+        or flow_mapping.get("locator_method") == "name-search"
+    )
+
+
+def render_verdict_block(flow_mapping: dict, verdict_line: str) -> str:
+    """Render the verdict block with or without the low-confidence warning."""
+    if should_warn(flow_mapping):
+        return f"{WARNING_PREFIX}\n{verdict_line}"
+    return verdict_line
+
+
+# --- Tests ---
+
+def test_low_confidence_triggers_warning():
+    fm = {"confidence": "low", "locator_method": "nav-graph", "mappings": []}
+    assert should_warn(fm) is True
+
+
+def test_name_search_triggers_warning():
+    fm = {"confidence": "high", "locator_method": "name-search", "mappings": []}
+    assert should_warn(fm) is True
+
+
+def test_medium_confidence_name_search_triggers_warning():
+    fm = {"confidence": "medium", "locator_method": "name-search", "mappings": []}
+    assert should_warn(fm) is True
+
+
+def test_high_confidence_nav_graph_no_warning():
+    fm = {"confidence": "high", "locator_method": "nav-graph", "mappings": []}
+    assert should_warn(fm) is False
+
+
+def test_medium_confidence_nav_graph_no_warning():
+    fm = {"confidence": "medium", "locator_method": "nav-graph", "mappings": []}
+    assert should_warn(fm) is False
+
+
+def test_warning_block_contains_expected_text():
+    fm = {"confidence": "low", "locator_method": "nav-graph", "mappings": []}
+    verdict_line = "> **Verdict:** 🟢 Ready to ship"
+    block = render_verdict_block(fm, verdict_line)
+    assert "⚠" in block
+    assert "Low-confidence anchor" in block
+    assert verdict_line in block
+
+
+def test_clean_block_has_no_warning():
+    fm = {"confidence": "high", "locator_method": "nav-graph", "mappings": []}
+    verdict_line = "> **Verdict:** 🟢 Ready to ship"
+    block = render_verdict_block(fm, verdict_line)
+    assert block == verdict_line
+    assert "⚠" not in block
+
+
+def test_refused_locator_no_warning_unless_low_confidence():
+    """A refused flow-mapping has no useful confidence signal — only the
+    confidence field itself determines whether the warning fires."""
+    fm = {"confidence": "high", "locator_method": "refused", "mappings": []}
+    assert should_warn(fm) is False
+
+    fm_low = {"confidence": "low", "locator_method": "refused", "mappings": []}
+    assert should_warn(fm_low) is True

--- a/skill-tests/design-coverage/tests/test_multi_anchor_disambiguate.py
+++ b/skill-tests/design-coverage/tests/test_multi_anchor_disambiguate.py
@@ -1,0 +1,108 @@
+"""Tests for multi-anchor disambiguation logic (wave 3 #4).
+
+The algorithm strips multi_anchor_suffixes from candidate class names, groups
+by base name, and flags any group with N >= 2 candidates as ambiguous.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).parents[1]
+FIXTURE = ROOT / "fixtures" / "stage-01" / "multi-anchor" / "input"
+
+
+# --- Algorithm helpers (mirrors stage 01 prose) ---
+
+def _strip_suffix(name: str, suffixes: list[str]) -> str:
+    for sfx in suffixes:
+        if name.endswith(sfx):
+            return name[: -len(sfx)]
+    return name
+
+
+def detect_multi_anchor_groups(
+    candidates: list[dict],
+    suffixes: list[str],
+) -> dict[str, list[dict]]:
+    """Return {base_name: [candidates]} for every group with N >= 2 members."""
+    from collections import defaultdict
+    groups: dict[str, list[dict]] = defaultdict(list)
+    for c in candidates:
+        base = _strip_suffix(c["class_name"], suffixes)
+        groups[base].append(c)
+    return {b: g for b, g in groups.items() if len(g) >= 2}
+
+
+def record_anchor_selection(
+    run_config: dict,
+    selected: str,
+    reason: str = "user-picked-multi-anchor",
+) -> dict:
+    """Return an updated run-config dict with the selected anchor recorded."""
+    return {**run_config, "selected_anchor": selected, "selected_anchor_reason": reason}
+
+
+# --- Fixtures ---
+
+def _load_suffixes() -> list[str]:
+    return json.loads((FIXTURE / "hint_suffixes.json").read_text())
+
+
+CANDIDATES_AMBIGUOUS = [
+    {"class_name": "AppointmentDetailsViewController",    "file": "AppointmentDetailsViewController.swift",    "mtime": "2024-11-08", "lines": 120},
+    {"class_name": "AppointmentDetailsHostingController", "file": "AppointmentDetailsHostingController.swift", "mtime": "2026-03-15", "lines": 47},
+]
+
+CANDIDATES_SINGLE = [
+    {"class_name": "AppointmentDetailsViewController", "file": "AppointmentDetailsViewController.swift", "mtime": "2024-11-08", "lines": 120},
+]
+
+CANDIDATES_DIFFERENT_BASE = [
+    {"class_name": "MBOApptDetailViewController",         "file": "MBOApptDetailViewController.m",             "mtime": "2024-11-08", "lines": 1842},
+    {"class_name": "AppointmentDetailsHostingController", "file": "AppointmentDetailsHostingController.swift", "mtime": "2026-03-15", "lines": 47},
+]
+
+
+# --- Tests ---
+
+def test_multi_anchor_detected():
+    suffixes = _load_suffixes()
+    groups = detect_multi_anchor_groups(CANDIDATES_AMBIGUOUS, suffixes)
+    assert "AppointmentDetails" in groups
+    assert len(groups["AppointmentDetails"]) == 2
+
+
+def test_single_anchor_not_flagged():
+    suffixes = _load_suffixes()
+    groups = detect_multi_anchor_groups(CANDIDATES_SINGLE, suffixes)
+    assert groups == {}
+
+
+def test_no_suffix_match_not_flagged():
+    """Spec's narrative example: different bases after stripping — not flagged."""
+    suffixes = _load_suffixes()
+    groups = detect_multi_anchor_groups(CANDIDATES_DIFFERENT_BASE, suffixes)
+    # MBOApptDetail != AppointmentDetails → no ambiguous group
+    assert groups == {}
+
+
+def test_run_config_records_selected_anchor():
+    base_config = {"figma_url": "https://figma.com/test", "platform": "ios"}
+    updated = record_anchor_selection(base_config, "AppointmentDetailsViewController")
+    assert updated["selected_anchor"] == "AppointmentDetailsViewController"
+    assert updated["selected_anchor_reason"] == "user-picked-multi-anchor"
+    # Original keys preserved
+    assert updated["figma_url"] == base_config["figma_url"]
+
+
+def test_fixture_files_exist():
+    assert (FIXTURE / "AppointmentDetailsViewController.swift").exists()
+    assert (FIXTURE / "AppointmentDetailsHostingController.swift").exists()
+    assert (FIXTURE / "hint_suffixes.json").exists()
+
+
+def test_empty_suffixes_never_flags():
+    groups = detect_multi_anchor_groups(CANDIDATES_AMBIGUOUS, [])
+    # With no suffixes, class names themselves are bases → different names → no group
+    assert groups == {}

--- a/skill-tests/design-coverage/tests/test_schemas_parse.py
+++ b/skill-tests/design-coverage/tests/test_schemas_parse.py
@@ -6,6 +6,6 @@ SCHEMAS = Path(os.environ["DESIGN_COVERAGE_SKILL_ROOT"]) / "schemas"
 
 def test_all_schemas_parse():
     files = sorted(SCHEMAS.glob("*.json"))
-    assert len(files) == 8, f"expected 8 schemas, found {len(files)}"
+    assert len(files) == 9, f"expected 9 schemas, found {len(files)}"
     for f in files:
         json.loads(f.read_text())

--- a/skill-tests/design-coverage/tests/test_stage3_zero_hotspots.py
+++ b/skill-tests/design-coverage/tests/test_stage3_zero_hotspots.py
@@ -8,7 +8,15 @@ SCHEMAS = Path(os.environ["DESIGN_COVERAGE_SKILL_ROOT"]) / "schemas"
 
 def stage3_resolve(inventory):
     hotspots = [i for i in inventory["items"] if i.get("hotspot")]
-    return {"resolved": []} if not hotspots else None
+    if not hotspots:
+        # Short-circuit: no hotspot questions, no candidate destinations.
+        # Still writes figma_dedup_policy with the default (wave 3 #5).
+        return {
+            "resolved": [],
+            "in_scope_destinations": [],
+            "figma_dedup_policy": "dark-twins-folded",
+        }
+    return None
 
 def test_zero_hotspots_short_circuits():
     inv = json.loads((FX / "input" / "code_inventory.json").read_text())

--- a/skills/design-tooling/design-coverage/SKILL.md
+++ b/skills/design-tooling/design-coverage/SKILL.md
@@ -285,11 +285,18 @@ The summary is for a designer / engineer reviewer who has ~2 minutes before thei
 
 1. **Non-deterministic banner** — write this HTML comment verbatim at the very top of `06-summary.md` (do **not** wrap it in a code fence; the banner is an actual HTML comment, not a code example): `<!-- Rendered by the main session from 06-report.json on <ISO-date>. Non-deterministic — re-running /design-coverage may produce different prose. The deterministic audit view is 06-report.md. -->`
 
-2. **One-line verdict** immediately after the title. Pick color by highest-severity summary entry (any `error` → red; any `warn` and no error → yellow; else green). The reason cites the specific gap that blocks shipping ("the Resource Picker modal has no Figma frame"), not a count ("2 errors need review").
+2. **One-line verdict** immediately after the title. Pick color by highest-severity summary entry (any `error` → red; any `warn` and no error → yellow; else green). The reason cites the specific gap that blocks shipping ("the Resource Picker modal has no Figma frame"), not a count ("2 errors need review"). Use exactly one of these formats:
+
+   ```
+   > **Verdict:** 🟢 Ready to ship
+   > **Verdict:** 🟡 Caveats below — {one-sentence reason}
+   > **Verdict:** 🔴 Not ready to ship: {one-sentence reason}
+   ```
 
    **Low-confidence anchor check (wave 3 #13):** Before writing the verdict line, read
    `<run-dir>/01-flow-mapping.json`. If `confidence == "low"` **OR**
-   `locator_method == "name-search"`, prepend the verdict block with a warning:
+   `locator_method == "name-search"`, prepend the warning immediately before whichever
+   verdict line was selected (green, yellow, or red):
 
    ```
    > ⚠ **Low-confidence anchor — review stage 1 before trusting this report.**
@@ -297,11 +304,7 @@ The summary is for a designer / engineer reviewer who has ~2 minutes before thei
    ```
 
    If `confidence` is `"high"` or `"medium"` AND `locator_method` is `"nav-graph"`,
-   emit the plain verdict line with no warning:
-
-   ```
-   > **Verdict:** 🟢 Ready to ship
-   ```
+   emit only the selected verdict line with no warning prepended.
 
 3. **Next 5 actions** — a numbered list of the 5 most actionable rows the reader should work on first (errors before warnings, highest-severity warnings before lower). This is what the reader reads in the first 30 seconds — it must be the top of the file, not buried after the tally.
 

--- a/skills/design-tooling/design-coverage/SKILL.md
+++ b/skills/design-tooling/design-coverage/SKILL.md
@@ -285,9 +285,42 @@ The summary is for a designer / engineer reviewer who has ~2 minutes before thei
 
 1. **Non-deterministic banner** — write this HTML comment verbatim at the very top of `06-summary.md` (do **not** wrap it in a code fence; the banner is an actual HTML comment, not a code example): `<!-- Rendered by the main session from 06-report.json on <ISO-date>. Non-deterministic — re-running /design-coverage may produce different prose. The deterministic audit view is 06-report.md. -->`
 
-2. **One-line verdict** immediately after the title: `> **Verdict:** 🟢 Ready to ship` / `🟡 Caveats below` / `🔴 Not ready to ship: <one-sentence reason>`. Pick color by highest-severity summary entry (any `error` → red; any `warn` and no error → yellow; else green). The reason cites the specific gap that blocks shipping ("the Resource Picker modal has no Figma frame"), not a count ("2 errors need review").
+2. **One-line verdict** immediately after the title. Pick color by highest-severity summary entry (any `error` → red; any `warn` and no error → yellow; else green). The reason cites the specific gap that blocks shipping ("the Resource Picker modal has no Figma frame"), not a count ("2 errors need review").
 
-3. **Next 5 actions** — a numbered list of the 5 most actionable rows the reader should work on first (errors before warnings, highest-severity warnings before lower). One sentence each, imperative voice, beginning with a verb ("Ask design to add…", "Confirm with product whether…", "Drop the legacy X path…"). This is what the reader reads in the first 30 seconds — it must be the top of the file, not buried after the tally.
+   **Low-confidence anchor check (wave 3 #13):** Before writing the verdict line, read
+   `<run-dir>/01-flow-mapping.json`. If `confidence == "low"` **OR**
+   `locator_method == "name-search"`, prepend the verdict block with a warning:
+
+   ```
+   > ⚠ **Low-confidence anchor — review stage 1 before trusting this report.**
+   > **Verdict:** 🟢 Ready to ship
+   ```
+
+   If `confidence` is `"high"` or `"medium"` AND `locator_method` is `"nav-graph"`,
+   emit the plain verdict line with no warning:
+
+   ```
+   > **Verdict:** 🟢 Ready to ship
+   ```
+
+3. **Next 5 actions** — a numbered list of the 5 most actionable rows the reader should work on first (errors before warnings, highest-severity warnings before lower). This is what the reader reads in the first 30 seconds — it must be the top of the file, not buried after the tally.
+
+   **Slot-fill template (wave 3 #12):** Each action **must** use the following template.
+   The `verb` slot is constrained to `ALLOWED_VERBS` from `lib/action_verbs.py`:
+   `Ask | Confirm | Drop | Document | Wire | Deprecate`. Fill every slot — do not
+   write free-form prose in place of the template.
+
+   ```
+   {N}. **{verb} {object}** — {legacy_ref} {has no | conflicts with} {figma_ref}.
+      {one-sentence consequence}. Action: {ask_design | confirm_with_product | document_as_dropped | wire_in_navigation}.
+   ```
+
+   Example:
+
+   ```
+   1. **Ask design to add Resource Picker frame** — `ResourcePickerViewController` has no Figma counterpart.
+      Without a frame, the comparison is incomplete and stage 5 flags it as missing. Action: ask_design.
+   ```
 
 4. **Severity tally table** — counts of 🔴/🟠/ℹ️ summary entries + counts of matrix statuses (`missing`, `new-in-figma`, `restructured`, `present`). Use the emoji in the table cells, not just the headers.
 

--- a/skills/design-tooling/design-coverage/lib/action_verbs.py
+++ b/skills/design-tooling/design-coverage/lib/action_verbs.py
@@ -1,0 +1,17 @@
+"""Constrained vocabulary for the stage-6 narrative next-5-actions block.
+
+Wave 3 #12 — replaces free-prose action instructions with a slot-fill template
+so two runs on the same 06-report.json produce matching verbs and noun-objects.
+"""
+from __future__ import annotations
+
+ALLOWED_VERBS: list[str] = ["Ask", "Confirm", "Drop", "Document", "Wire", "Deprecate"]
+
+# Display guide for agent use — NOT a str.format() template.
+# Slots with `|`-delimited options (e.g., `{has no | conflicts with}`) are
+# prose choices; the agent picks one. Do NOT call .format() on this string.
+ACTION_TEMPLATE_DISPLAY: str = (
+    "{N}. **{verb} {object}** — {legacy_ref} {has no | conflicts with} {figma_ref}.\n"
+    "   {one-sentence consequence}. "
+    "Action: {ask_design | confirm_with_product | document_as_dropped | wire_in_navigation}."
+)

--- a/skills/design-tooling/design-coverage/schemas/clarifications.json
+++ b/skills/design-tooling/design-coverage/schemas/clarifications.json
@@ -28,6 +28,10 @@
           }
         }
       }
+    },
+    "figma_dedup_policy": {
+      "type": "string",
+      "enum": ["none", "dark-twins-folded", "appearance-modes-folded"]
     }
   }
 }

--- a/skills/design-tooling/design-coverage/schemas/frame_classification.json
+++ b/skills/design-tooling/design-coverage/schemas/frame_classification.json
@@ -1,0 +1,20 @@
+{
+  "$id": "frame_classification.json",
+  "type": "object",
+  "required": ["frames"],
+  "properties": {
+    "frames": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["frame_id", "name", "is_leaf", "figma_parent_id"],
+        "properties": {
+          "frame_id":        { "type": "string",          "minLength": 1 },
+          "name":            { "type": "string",          "minLength": 1 },
+          "is_leaf":         { "type": "boolean"                        },
+          "figma_parent_id": { "type": ["string", "null"]               }
+        }
+      }
+    }
+  }
+}

--- a/skills/design-tooling/design-coverage/schemas/inventory_item.json
+++ b/skills/design-tooling/design-coverage/schemas/inventory_item.json
@@ -7,7 +7,7 @@
     "kind": {
       "type": "string",
       "x-platform-pattern": true,
-      "enum": ["screen", "state", "action", "field"]
+      "enum": ["screen", "screen-group", "state", "action", "field"]
     },
     "title": {"type": "string", "minLength": 1},
     "parent_id": {"type": ["string", "null"]},

--- a/skills/design-tooling/design-coverage/stages/01-flow-locator.md
+++ b/skills/design-tooling/design-coverage/stages/01-flow-locator.md
@@ -44,6 +44,76 @@ The `mappings[].android_destination` key name is inherited from the Android port
 4. **Pass 2 — name-search fallback (only if Pass 1 yields no medium-confidence match).** Tokenize Figma frame names + hint. Grep against the platform's screen-unit anchors (see hints). Rank by distinct-anchor count. Set `locator_method: "name-search"`.
 5. **Refuse loudly on no locatable entry.** If neither pass produces at least one high-or-medium-confidence mapping, write `locator_method: "refused"` with a `refused_reason` suggesting `--old-flow <hint>` and exit.
 
+## Multi-anchor disambiguation (wave 3 #4)
+
+After the candidate-class grep loop (Pass 1 and/or Pass 2) has produced candidates,
+run multi-anchor detection **before** writing `01-flow-mapping.json`.
+
+```python
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path.cwd() / "lib"))
+from hint_frontmatter import parse_hint_frontmatter
+
+# multi_anchor_suffixes comes from the platform hint's frontmatter.
+# Default to [] when the field is absent (hint has no ambiguous-suffix pairs).
+hint_text = (PLATFORMS_DIR / f"{context.platform}.md").read_text(encoding="utf-8")
+fm = parse_hint_frontmatter(hint_text)
+multi_anchor_suffixes: list[str] = fm.get("multi_anchor_suffixes", [])
+
+
+def _strip_suffix(name: str, suffixes: list[str]) -> str:
+    """Return name with the first matching suffix removed; original name if none match."""
+    for sfx in suffixes:
+        if name.endswith(sfx):
+            return name[: -len(sfx)]
+    return name
+
+
+# Group candidates by their stripped base name.
+from collections import defaultdict
+groups: dict[str, list[dict]] = defaultdict(list)
+for candidate in candidates:  # each dict has at least "class_name", "file", "mtime", "lines"
+    base = _strip_suffix(candidate["class_name"], multi_anchor_suffixes)
+    groups[base].append(candidate)
+
+# For each group with N ≥ 2 members, ask the user which to use.
+for base_name, group in sorted(groups.items()):
+    if len(group) < 2:
+        continue
+    # Build a choice list for AskUserQuestion.
+    choices = [
+        f"{c['class_name']} ({c['file']}, last modified {c['mtime']}, {c['lines']} lines)"
+        for c in group
+    ]
+    question = (
+        f"Found multiple anchors sharing base `{base_name}`:\n"
+        + "".join(f"  - {ch}\n" for ch in choices)
+        + "\nWhich should anchor the audit?"
+    )
+    # Ask interactively — never a file handoff.
+    answer = AskUserQuestion(question, choices)
+    selected_class = next(
+        c["class_name"] for c in group if answer.startswith(c["class_name"])
+    )
+    # Remove non-selected candidates from the list.
+    candidates = [c for c in candidates if c["class_name"] not in
+                  [g["class_name"] for g in group] or c["class_name"] == selected_class]
+    # Record the choice in run-config.
+    run_config["selected_anchor"] = selected_class
+    run_config["selected_anchor_reason"] = "user-picked-multi-anchor"
+    # Persist the updated run-config.
+    import json
+    (run_dir / "00-run-config.json").write_text(
+        json.dumps(run_config, indent=2), encoding="utf-8"
+    )
+```
+
+> **Invariant:** Multi-anchor disambiguation is **interactive in-session** (via the
+> live `AskUserQuestion` interface). Never write the question to a file for the user
+> to edit offline. If `multi_anchor_suffixes` is empty or no group has N ≥ 2
+> candidates, this block is a no-op and the run proceeds normally.
+
 ## Output
 
 Write `01-flow-mapping.json` to the run dir, then regenerate the Markdown view:

--- a/skills/design-tooling/design-coverage/stages/01-flow-locator.md
+++ b/skills/design-tooling/design-coverage/stages/01-flow-locator.md
@@ -50,14 +50,21 @@ After the candidate-class grep loop (Pass 1 and/or Pass 2) has produced candidat
 run multi-anchor detection **before** writing `01-flow-mapping.json`.
 
 ```python
+import json
+import os
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path.cwd() / "lib"))
 from hint_frontmatter import parse_hint_frontmatter
+from skill_io import atomic_write_json
+
+PLATFORMS_DIR = Path(os.environ["DESIGN_COVERAGE_PLATFORMS_DIR"])
+run_config = json.loads((run_dir / "00-run-config.json").read_text(encoding="utf-8"))
+platform = run_config["platform"]
 
 # multi_anchor_suffixes comes from the platform hint's frontmatter.
 # Default to [] when the field is absent (hint has no ambiguous-suffix pairs).
-hint_text = (PLATFORMS_DIR / f"{context.platform}.md").read_text(encoding="utf-8")
+hint_text = (PLATFORMS_DIR / f"{platform}.md").read_text(encoding="utf-8")
 fm = parse_hint_frontmatter(hint_text)
 multi_anchor_suffixes: list[str] = fm.get("multi_anchor_suffixes", [])
 
@@ -102,11 +109,8 @@ for base_name, group in sorted(groups.items()):
     # Record the choice in run-config.
     run_config["selected_anchor"] = selected_class
     run_config["selected_anchor_reason"] = "user-picked-multi-anchor"
-    # Persist the updated run-config.
-    import json
-    (run_dir / "00-run-config.json").write_text(
-        json.dumps(run_config, indent=2), encoding="utf-8"
-    )
+    # Persist the updated run-config atomically so resumes never see partial JSON.
+    atomic_write_json(run_dir / "00-run-config.json", run_config)
 ```
 
 > **Invariant:** Multi-anchor disambiguation is **interactive in-session** (via the

--- a/skills/design-tooling/design-coverage/stages/03-clarification.md
+++ b/skills/design-tooling/design-coverage/stages/03-clarification.md
@@ -103,15 +103,35 @@ Persist the user's selections in `03-clarifications.json`'s
 Stage 05 reads this list to know which candidates to flag as `missing` if
 Figma has no counterpart.
 
+### C. Figma deduplication policy (wave 3 #5)
+
+After questions A and B, emit one final question about Figma appearance-variant
+folding. Always ask this question, regardless of whether A and B produced any items:
+
+> "How should Figma appearance variants (light/dark mode, etc.) be handled in the
+> inventory?
+>  - `none` — keep all variants as separate inventory items
+>  - `dark-twins-folded` *(default)* — fold light/dark pairs into one item with
+>    `modes: ["light", "dark"]`
+>  - `appearance-modes-folded` — fold all appearance variants (including dynamic
+>    type, high-contrast) into one item"
+
+Present options `["none", "dark-twins-folded", "appearance-modes-folded"]` via
+`AskUserQuestion`; default answer is `"dark-twins-folded"` if the user does not
+respond. Persist in `03-clarifications.json` as a top-level `figma_dedup_policy`
+field.
+
 ### Short-circuit on empty
 
 If both `emit_questions_for_inventory` returns `[]` AND `candidate_destinations`
-is empty, write `{"resolved": [], "in_scope_destinations": []}` to
-`03-clarifications.json` immediately and exit. Do not enter a dialogue.
+is empty, skip questions A and B. Still ask question C (the `figma_dedup_policy`
+question). Write `{"resolved": [], "in_scope_destinations": [], "figma_dedup_policy": "dark-twins-folded"}`
+(or the user's chosen value) to `03-clarifications.json` and exit.
 
 ## Output
 
-Write `03-clarifications.json` to the run dir conforming to the skill's `schemas/clarifications.json`, then regenerate the Markdown view:
+Write `03-clarifications.json` to the run dir conforming to the skill's `schemas/clarifications.json`
+(which now includes the optional `figma_dedup_policy` field), then regenerate the Markdown view:
 
 ```python
 import sys

--- a/skills/design-tooling/design-coverage/stages/04-figma-inventory.md
+++ b/skills/design-tooling/design-coverage/stages/04-figma-inventory.md
@@ -30,13 +30,89 @@ Shape:
 
 Then regenerate `<run_dir>/04-figma-inventory.md` via the inline pattern shown in "Atomic write pattern" below (extend with `(run_dir / "04-figma-inventory.md").write_text(render_figma_inventory(inventory))`).
 
+## Frame classification and dedup policy (wave 3 #5)
+
+### Step 0 — Classify frames and emit `00-frame-classification.json`
+
+Before the per-frame loop, classify every in-scope Figma frame as leaf or non-leaf,
+and emit the classification as a top-level pipeline artifact. Write this file
+**unconditionally** on every invocation (including resumes) — it is deterministic
+so re-writing is safe. Do NOT skip the write when the file already exists.
+
+A **leaf frame** = `type == "FRAME"` AND has no direct `FRAME`-type children.
+
+```python
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path.cwd() / "lib"))
+from skill_io import validate_and_write_json, read_json
+from skill_root import get_skill_root
+
+# all_in_scope_frames: list of raw Figma frame dicts from the MCP response.
+# Each has at least: {"id": ..., "name": ..., "type": ..., "children": [...], "parentId": ...}
+def _is_leaf(frame: dict) -> bool:
+    return not any(c.get("type") == "FRAME" for c in frame.get("children", []))
+
+frame_classification = {
+    "frames": [
+        {
+            "frame_id":        f["id"],
+            "name":            f["name"],
+            "is_leaf":         _is_leaf(f),
+            "figma_parent_id": f.get("parentId"),  # Figma node parent ID (not pipeline parent_id)
+        }
+        for f in all_in_scope_frames
+    ]
+}
+validate_and_write_json(
+    run_dir / "00-frame-classification.json",
+    frame_classification,
+    "frame_classification.json",
+    get_skill_root() / "schemas",
+)
+```
+
+This replaces the old `<run_dir>/.scratch/_in_scope_with_names.json` scratch pattern.
+
+### Step 0b — Read `figma_dedup_policy`
+
+```python
+clarifications = read_json(run_dir / "03-clarifications.json") or {}
+figma_dedup_policy = clarifications.get("figma_dedup_policy", "dark-twins-folded")
+```
+
+The policy controls how appearance-variant twin frames are folded in step 3 below.
+
+### Section-level frames → `kind: "screen-group"`
+
+Non-leaf frames (those with `FRAME` children) are section-level groupings. Emit each
+as a `kind: "screen-group"` `InventoryItem` with `parent_id: null` — no MCP call
+or screenshot needed, just the frame name and metadata. Only leaf frames go through
+the full per-frame procedure below.
+
 ## Per-frame procedure
 
-For each in-scope top-level Figma frame:
+Process **only leaf frames** (those with `is_leaf: true` in the classification).
+For each leaf frame:
 
 1. Call `mcp__plugin_figma_figma__get_design_context(fileKey, nodeId=frame_id)` to get structured data (layers, components, text, design tokens, annotations, Code Connect mappings).
 2. Call `mcp__plugin_figma_figma__get_screenshot(fileKey, nodeId=frame_id)`.
-3. Extract `InventoryItem` rows for the frame itself (`kind: "screen"`) plus each meaningful state/action/field inside it. Use stable slug IDs rooted at the frame (e.g., `appt-details.header.save-button`). Set `parent_id` to build the screen → state → action/field hierarchy. When a Figma frame has sibling light/dark (or other appearance-variant) twins of the same logical screen, emit **one** inventory item with `modes: ["light", "dark"]` — not two separate rows. This prevents the comparison matrix from doubling up on visual variants. When a frame's intent is unclear from metadata alone (e.g., it's labelled as a demo or coachmark), set `ambiguous: true` with a one-sentence `ambiguity_reason` — stage 5 will surface it in the report.
+3. Extract `InventoryItem` rows for the frame itself (`kind: "screen"`) plus each meaningful state/action/field inside it. Use stable slug IDs rooted at the frame (e.g., `appt-details.header.save-button`). Set `parent_id` to build the screen → state → action/field hierarchy.
+
+   **Appearance-variant folding** (apply `figma_dedup_policy`):
+   - `"none"` → emit every variant as its own `InventoryItem`.
+   - `"dark-twins-folded"` *(default)* → when two leaf frames share the same logical
+     name and differ only by a light/dark appearance suffix (e.g., `Appt Details – Light`
+     and `Appt Details – Dark`), emit **one** item with `modes: ["light", "dark"]`
+     instead of two separate rows. This prevents the comparison matrix from doubling
+     up on visual variants.
+   - `"appearance-modes-folded"` → fold all appearance-variant twins (including
+     dynamic type, high-contrast) into one item; populate `modes` with all detected
+     variant labels.
+
+   When a frame's intent is unclear from metadata alone (e.g., labelled as a demo
+   or coachmark), set `ambiguous: true` with a one-sentence `ambiguity_reason` —
+   stage 5 will surface it in the report.
 4. Compare structured data against the screenshot. Set `screenshot_cross_check`:
    - `agreed` — structured data and screenshot tell the same story.
    - `disagreed` — they differ meaningfully (e.g., a button labelled "Save" in metadata shows as "Continue" in the pixels). Stage 5 will bump severity on any comparison row referencing this frame.

--- a/skills/design-tooling/design-coverage/stages/04-figma-inventory.md
+++ b/skills/design-tooling/design-coverage/stages/04-figma-inventory.md
@@ -11,11 +11,14 @@ Build a structured inventory of the Figma design's screens, states, actions, and
 ## Inputs
 
 - `<run_dir>/01-flow-mapping.json` (Stage 1) — tells you which Figma frames are in-scope.
+- `<run_dir>/03-clarifications.json` (Stage 3) — provides `figma_dedup_policy` for appearance-variant folding.
 - Figma MCP tools: `mcp__plugin_figma_figma__get_design_context` and `mcp__plugin_figma_figma__get_screenshot` (paired per frame).
 
 ## Output
 
 Write `<run_dir>/04-figma-inventory.json`. Schema: [`schemas/figma_inventory.json`](../schemas/figma_inventory.json).
+
+Also writes `<run_dir>/00-frame-classification.json` (wave 3 #5). Schema: [`schemas/frame_classification.json`](../schemas/frame_classification.json). Written unconditionally before the per-frame loop — see "Frame classification" section below.
 
 Shape:
 

--- a/skills/design-tooling/design-coverage/stages/06-report-generator.md
+++ b/skills/design-tooling/design-coverage/stages/06-report-generator.md
@@ -117,6 +117,19 @@ If a deployment needs `missing` rows on a matrix (e.g., for a code-first coverag
 
 This stage writes the deterministic audit view (`06-report.md`). The verdict-first narrative summary at `06-report.json` → `06-summary.md` is rendered by the **main session**, not a subagent, once this stage returns. See SKILL.md § "Final output" for the required structure. Keeping the narrative render out-of-stage means this stage stays deterministic and testable; the narrative is explicitly labeled non-deterministic.
 
+**Cross-references for the narrative render (wave 3):**
+
+- **Low-confidence anchor warning (#13):** The narrative render reads
+  `<run-dir>/01-flow-mapping.json` fields `confidence` and `locator_method`.
+  If `confidence == "low"` OR `locator_method == "name-search"`, it prepends the
+  verdict line with `⚠ **Low-confidence anchor — review stage 1 before trusting
+  this report.**` See SKILL.md § "Final output" → "Required structure" item 2.
+
+- **Next-5-actions slot-fill template (#12):** The narrative render constructs each
+  action using the template and `ALLOWED_VERBS` from `lib/action_verbs.py`. The verb
+  slot is constrained to `Ask | Confirm | Drop | Document | Wire | Deprecate`.
+  See SKILL.md § "Final output" → "Required structure" item 3.
+
 ## Scope fence — what this stage MUST NOT write
 
 This stage writes exactly two files:


### PR DESCRIPTION
## Summary

Full implementation of Wave 3 for the design-coverage skill (issue #13). The plan doc and all code changes are included in this PR.

Plan doc: [`docs/superpowers/specs/2026-04-25-wave3-implementation-plan.md`](docs/superpowers/specs/2026-04-25-wave3-implementation-plan.md)

### What wave 3 covers

| ID  | Title                          | Files touched |
|-----|-------------------------------|---------------|
| #4  | Multi-anchor disambiguation    | `stages/01-flow-locator.md` |
| #5  | Frame-granularity policy       | `schemas/inventory_item.json`, `schemas/frame_classification.json` (new), `schemas/clarifications.json`, `stages/03-clarification.md`, `stages/04-figma-inventory.md` |
| #12 | Next-5-actions template        | `lib/action_verbs.py` (new), `SKILL.md` |
| #13 | Low-confidence verdict warning | `SKILL.md`, `stages/06-report-generator.md` |

Plus 4 new test files + fixtures under `skill-tests/design-coverage/tests/` (182 tests passing).

### Key design decisions

- `screen-group` added to `inventory_item.kind` enum; flows into `get_sealed_enum_pattern_keys()` automatically (no extra wiring).
- `00-frame-classification.json` promoted from `.scratch/` to a real pipeline artifact with a validated schema; written unconditionally on every invocation including resumes.
- `figma_dedup_policy` stored as a top-level field in `03-clarifications.json` (not a hotspot `resolved[]` entry) because it is a global policy, not a per-hotspot decision.
- Multi-anchor disambiguation is **interactive in-session** via `AskUserQuestion` — never a file handoff. Groups N ≥ 2 candidates sharing a base name into one question.
- `ACTION_TEMPLATE_DISPLAY` is a prose guide for agents, not a callable `str.format()` template — slots like `{has no | conflicts with}` are intentionally invalid Python format placeholders.
- Low-confidence warning and slot-fill template both live in SKILL.md "Final output" (the narrative render), not in stage 06's deterministic report.

## Test plan

- [x] `schemas/frame_classification.json` — 7 tests (`test_frame_classification_schema.py`)
- [x] `lib/action_verbs.py` — 7 tests (`test_action_verbs.py`), including machine-check that `.format()` raises `KeyError`
- [x] Low-confidence verdict logic — 8 tests (`test_low_confidence_verdict.py`)
- [x] Multi-anchor disambiguation algorithm — 6 tests (`test_multi_anchor_disambiguate.py`)
- [x] Zero-hotspot short-circuit fixture updated to include `figma_dedup_policy`
- [x] `test_schemas_parse.py` count bumped 8 → 9
- [x] All 182 tests passing

https://claude.ai/code/session_015F1iurcJuX3tjwh6ikNJjx