### PR TITLE
feat(api-e2e): interview-driven staging E2E test-pass skill for backend APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ User-level Claude Code skills maintained by @prpande.
 | [`pr-followup`](./skills/pr-tooling/pr-followup/SKILL.md) | Re-enter the same comment loop later when human or late bot comments arrive. |
 | [`design-coverage`](./skills/design-tooling/design-coverage/SKILL.md) | Compare an existing in-code UI flow against a new Figma design and produce an auditable discrepancy report. |
 | [`design-coverage-scout`](./skills/design-tooling/design-coverage-scout/SKILL.md) | Companion skill that inspects an unfamiliar repo and emits a new `platforms/<name>.md` hint file for `design-coverage`. |
+| [`api-e2e`](./skills/api-tooling/api-e2e/SKILL.md) | Interview-driven, fresh-context staging E2E validation of a backend API PR or deployed endpoint: repo-head-derived expectations, build fingerprinting, risk-tiered matrix, four-way failure triage, redacted durable report. |
 
 ## Supporting library
 
@@ -41,6 +42,7 @@ ln -s "$PWD/skills/pr-tooling/pr-followup"               "$HOME/.claude/skills/p
 ln -s "$PWD/skills/pr-tooling/pr-loop-lib"               "$HOME/.claude/skills/pr-loop-lib"
 ln -s "$PWD/skills/design-tooling/design-coverage"       "$HOME/.claude/skills/design-coverage"
 ln -s "$PWD/skills/design-tooling/design-coverage-scout" "$HOME/.claude/skills/design-coverage-scout"
+ln -s "$PWD/skills/api-tooling/api-e2e"                  "$HOME/.claude/skills/api-e2e"
 ```
 
 On Windows with Git Bash, use `cmd //c mklink /D` or copy:
@@ -51,6 +53,7 @@ cp -r skills/pr-tooling/pr-followup               "$HOME/.claude/skills/pr-follo
 cp -r skills/pr-tooling/pr-loop-lib               "$HOME/.claude/skills/pr-loop-lib"
 cp -r skills/design-tooling/design-coverage       "$HOME/.claude/skills/design-coverage"
 cp -r skills/design-tooling/design-coverage-scout "$HOME/.claude/skills/design-coverage-scout"
+cp -r skills/api-tooling/api-e2e                  "$HOME/.claude/skills/api-e2e"
 ```
 
 After installation, restart your Claude Code session. The skills appear in

--- a/docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md
+++ b/docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md
@@ -1,0 +1,891 @@
+# api-e2e Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `api-e2e` skill — interview-driven, fresh-context staging E2E validation of a backend API PR or deployed endpoint — per the approved spec `docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md` (two ce-doc-review rounds applied, commit `617a379`).
+
+**Architecture:** Orchestrator `SKILL.md` (~150 lines: frontmatter, doctrine, phase table, gate summary) plus eight step files under `steps/`, one per phase, each ending with its exit gate. New `api-tooling` category directory alongside `pr-tooling`. All deliverables are markdown; run-time artifacts live in the session scratchpad under `{scratchpad}/api-e2e/`.
+
+**Tech Stack:** Markdown + YAML frontmatter (skill file format). The skill itself drives `bash`/`curl`/`jq`/`python` at run time; nothing here installs anything.
+
+**Working directory:** `C:\src\skills-wt\api-e2e-skill` on branch `api-e2e-skill` (worktree of `C:\src\skills`). All paths below are repo-relative to that worktree.
+
+**"Testing":** Markdown prose — no unit-test runner. Structural validation via existing `python scripts/validate.py` (UTF-8, frontmatter, placeholder markers, internal `steps/NN-*.md` reference resolution). Per-task cadence: write file → validate → commit. The spec's acceptance tests (replay + transfer) are post-implementation manual exercises, out of this plan's scope.
+
+## Global Constraints
+
+- Doctrine 3 (spec): skill text contains **method only — zero environment facts**. No service names, URLs, tenant/subscriber numbers, IDs, or platform quirks in any file. All examples generic ("the service", "domain A").
+- Doctrine 6 (spec): token-mint curls and credentials are **session-scoped** — the skill text must direct them to the session scratchpad only, never to committed/persistent/memory files.
+- Step files are named with **two-digit prefixes** (`steps/00-preflight.md` … `steps/07-cleanup.md`), matching the pr-autopilot convention and the validator's `steps/NN-*.md` reference pattern. (Deviation from the spec's illustrative single-digit names `steps/0-preflight.md`; recorded here deliberately.)
+- The validator rejects line-initial `[TBD]`, `TODO: `, `[fill in`, `XXX ` outside code fences — never leave them in any file.
+- Every file UTF-8, LF or CRLF both tolerated.
+- **Resolved open question** (spec's Deferred section, decided by this plan and recorded back into the spec in Task 10): subagent fan-out in phase 2/4 triggers at a **fixed default of ≥ 10 wire-observable deltas** in the phase-2 delta map; the interview may override in either direction. Deterministic for the acceptance replay.
+- Run artifacts contract (consumed across step files — exact paths):
+  - `{scratchpad}/api-e2e/run-context.md` — capability table, interview answers, mode, permissions
+  - `{scratchpad}/api-e2e/secrets/mint-<domain>.sh` — token-mint scripts (session-scoped)
+  - `{scratchpad}/api-e2e/delta-map.md` — phase-2a output
+  - `{scratchpad}/api-e2e/no-touch.md` — phase-2b inventory
+  - `{scratchpad}/api-e2e/deploy-model.md` — phase-2c
+  - `{scratchpad}/api-e2e/fingerprint.md` — phase-2d (rung, assertion command)
+  - `{scratchpad}/api-e2e/matrix.md` — full untrimmed matrix with tiers
+  - `{scratchpad}/api-e2e/scripts/matrix-<n>.sh`, `{scratchpad}/api-e2e/results/` — executables + captures
+  - `{scratchpad}/api-e2e/report.md` — assembled report
+
+**File map** (all NEW unless noted):
+
+```
+skills/api-tooling/api-e2e/SKILL.md                    (Task 9)
+skills/api-tooling/api-e2e/steps/00-preflight.md       (Task 1)
+skills/api-tooling/api-e2e/steps/01-interview.md       (Task 2)
+skills/api-tooling/api-e2e/steps/02-ground-truth.md    (Task 3)
+skills/api-tooling/api-e2e/steps/03-environment-gate.md(Task 4)
+skills/api-tooling/api-e2e/steps/04-matrix.md          (Task 5)
+skills/api-tooling/api-e2e/steps/05-execute.md         (Task 6)
+skills/api-tooling/api-e2e/steps/06-report.md          (Task 7)
+skills/api-tooling/api-e2e/steps/07-cleanup.md         (Task 8)
+README.md                                              (EDIT, Task 10)
+docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md (EDIT, Task 10 — record resolved open question)
+```
+
+---
+
+## Phase A — Step files (each self-contained; validator passes without SKILL.md, per the pr-loop-lib precedent)
+
+### Task 1: Create `steps/00-preflight.md`
+
+**Files:**
+- Create: `skills/api-tooling/api-e2e/steps/00-preflight.md`
+
+**Interfaces:**
+- Consumes: nothing (first phase).
+- Produces: `{scratchpad}/api-e2e/run-context.md` with a **Capabilities** table (`capability | status: tool|user-mediated | detail`) that steps 01/03/05 read.
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+# Phase 0 — Preflight: tooling & access probe
+
+Detect what exists on this machine. Every gap degrades to "ask the user" —
+nothing is assumed installed, and no missing tool blocks the run.
+
+Create the run workspace first:
+
+```bash
+mkdir -p "{scratchpad}/api-e2e/secrets" "{scratchpad}/api-e2e/scripts" "{scratchpad}/api-e2e/results"
+```
+
+## Probe (non-fatal, one pass)
+
+Run each probe; record the outcome in the Capabilities table:
+
+```bash
+gh --version        # GitHub CLI
+az --version        # Azure CLI (optional, heaviest dependency — never required)
+curl --version
+jq --version || python --version   # at least one JSON processor
+git rev-parse --show-toplevel      # inside the target repo? (run from the repo if known)
+```
+
+For MCP-provided pipeline tools (e.g., an Azure DevOps MCP server), use
+ToolSearch with a keyword query like "pipelines get build" — presence of
+matching tools means MCP access exists. Interactively-authenticated MCP
+servers may be absent in headless runs; treat absence as a normal gap.
+
+## Access ladders (record the selected rung per capability)
+
+**Target repo access** — the run derives everything from the deployed repo
+head, so one of these must exist:
+1. A local checkout the run can `git -C <path>` into at the right commit.
+2. A GitHub (or equivalent) token the user pastes — verify with one benign
+   API read before recording it as working.
+3. Last resort: the user pastes specific files on request. Acceptable but
+   slow; tell the user derivation quality depends on what they paste.
+
+**Pipeline visibility** (PR mode deploy monitoring only — zero pipeline
+access is acceptable because the build fingerprint, not the pipeline, is
+ground truth for what is deployed):
+1. MCP pipeline tools (if the probe found them).
+2. Plain REST with a user-supplied PAT (read scope for builds), Basic auth
+   via curl. A raw pipeline URL (e.g., `dev.azure.com/...`) is NOT directly
+   fetchable without auth — never assume it is.
+3. The user runs the check themselves and pastes the result.
+
+## Capabilities table
+
+Write `{scratchpad}/api-e2e/run-context.md` starting with:
+
+```markdown
+# api-e2e run context
+## Capabilities
+| capability | status | detail |
+|---|---|---|
+| repo access | tool / user-mediated | <rung + how verified> |
+| pipeline visibility | tool / user-mediated / none | <rung> |
+| http client | tool | curl <version> |
+| json processor | tool | jq / python |
+```
+
+Secrets never go into this file — mint scripts live in
+`{scratchpad}/api-e2e/secrets/` only.
+
+## Gate
+
+The run knows, for each capability it will need, either a working tool or
+the user-mediated fallback. Do not proceed to the interview until the
+Capabilities table has a row for repo access, pipeline visibility, http
+client, and JSON processor.
+````
+
+- [ ] **Step 2: Validate**
+
+Run: `cd /c/src/skills-wt/api-e2e-skill && python scripts/validate.py`
+Expected: exit 0, `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/api-tooling/api-e2e/steps/00-preflight.md
+git commit -m "feat(api-e2e): phase-0 preflight step"
+```
+
+### Task 2: Create `steps/01-interview.md`
+
+**Files:**
+- Create: `skills/api-tooling/api-e2e/steps/01-interview.md`
+
+**Interfaces:**
+- Consumes: Capabilities table from `{scratchpad}/api-e2e/run-context.md` (Task 1 shape).
+- Produces: interview sections appended to `run-context.md` (`## Mode`, `## Target`, `## Environment`, `## Data permissions`, `## Report destination`); `secrets/mint-<domain>.sh` per domain. The **re-interview loop-back** procedure defined here is invoked by steps 02 and 04.
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+# Phase 1 — Interview
+
+Structured, back-and-forth, one topic at a time. The interview is where the
+operator's environment knowledge enters the run — the skill supplies the
+method, the operator supplies the environment. Never presume: any missing
+capability, credential, permission, or fixture becomes a question. Use
+AskUserQuestion for crisp either/or choices; plain prose for open answers.
+
+## Operator prerequisites — state these up front
+
+The operator must bring: access to the target environment; base URL(s) and
+a safe tenant; a token-mint recipe per domain the tests will call;
+authority to designate mutable data and to create fixtures in domains not
+exposed to the run. If a prerequisite is missing, name exactly which one —
+never silently block.
+
+## Memory-seeded fast path
+
+If local memory carries prior answers for this service (base URLs, tenant,
+token-mint recipe, data permissions), present them as prefilled hypotheses
+for one-shot confirm-or-correct instead of asking each topic cold.
+Confirmed values remain hypotheses until verified live — memory never
+substitutes for probing.
+
+## Collect (in order; append each answer to run-context.md)
+
+1. **Mode** — open PR (deploy + fingerprint + test) vs. already-deployed.
+2. **Target** — service under test; the PR or endpoint(s); any secondary
+   domains the tests will call.
+3. **Deployed ref** (deployed mode only) — which commit/branch/tag is live.
+   This is what phase 2 derives from and phase 3 verifies. If the ref is a
+   branch name, resolve and record the commit SHA now — branches move.
+4. **Environment** — base URL(s); tenant/subscriber to use.
+5. **Auth** — one token-mint curl per domain. Save each as
+   `{scratchpad}/api-e2e/secrets/mint-<domain>.sh`; run it; verify the
+   token with a benign read against that domain before accepting it; note
+   expiry behavior for mid-run re-mint. Secrets live ONLY under
+   `secrets/` — never in run-context.md, reports, memory, or any commit.
+6. **Data permissions** — which pre-existing data the run may *reference*
+   (read/associate, never mutate) and which objects the user designates
+   *mutable*. Ask explicitly about anything ambiguous.
+   **Read-only fallback:** if the user cannot confidently answer a
+   data-permission or tenant-safety question, the run proceeds read-only
+   until an authoritative answer arrives. Read-only means safe verbs only —
+   write-verb requests, INCLUDING expected-rejection probes (a POST
+   asserted to 400), count as write coverage and are recorded as gaps.
+   If the phase-2 delta map later shows coverage is predominantly
+   write-dependent, state the projected coverage of a read-only pass and
+   get an explicit proceed-or-defer decision before continuing past
+   phase 2.
+7. **Deploy preference** (PR mode) — prefer the user deploys (deployment
+   variables are theirs); or the user provides a pipeline run URL to
+   monitor; or the user authorizes the skill to trigger the pipeline —
+   only after confirming its exact identity (phase 3).
+8. **Report destination** — a durable, user-approved destination is
+   mandatory in both modes, alongside the scratchpad working copy.
+   PR mode: the PR itself (comment). Deployed mode: ONE canonical
+   per-service destination (e.g., a fixed per-service wiki index page every
+   deployed-mode run appends to), agreed once and confirmed here — so the
+   union of runs stays observable. The skill never commits reports to a
+   repo; no future run reads a past report as authority.
+
+## Re-interview loop-back (referenced by later phases)
+
+When any later phase discovers a newly required domain (e.g., a
+side-effect witness API surfaced by phase-2 derivation), return HERE for
+that domain only: collect its token-mint curl, verify with a benign read,
+record its data permissions, then resume the interrupted phase.
+
+## Gate
+
+Every interview-known domain has a verified token; mode, target, and data
+permissions are explicit in run-context.md. Do not start derivation until
+this holds.
+````
+
+- [ ] **Step 2: Validate**
+
+Run: `python scripts/validate.py`
+Expected: exit 0, `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/api-tooling/api-e2e/steps/01-interview.md
+git commit -m "feat(api-e2e): phase-1 interview step"
+```
+
+### Task 3: Create `steps/02-ground-truth.md`
+
+**Files:**
+- Create: `skills/api-tooling/api-e2e/steps/02-ground-truth.md`
+
+**Interfaces:**
+- Consumes: `run-context.md` (mode, target, deployed ref); repo access rung from Capabilities.
+- Produces: `delta-map.md`, `no-touch.md`, `deploy-model.md`, `fingerprint.md` (with `rung: 1|2|3` and the exact assertion command). Steps 03/04/05 read all four.
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+# Phase 2 — Ground truth from repo head
+
+Everything is derived from the deployed commit, freshly, this run. The
+three information sources are the repo head, live probing, and the
+interview — a memory hint may point you at code, but the code decides.
+
+## a. Wire-observable behavior map → delta-map.md
+
+PR mode: map EVERY commit in the diff to its observable effects — status
+codes, exact validation messages, error payload shapes
+(type/title/detail/extensions), precedence ordering among failures,
+headers (e.g., Retry-After), side effects and the read APIs that witness
+them. Deployed mode: do the same for the target endpoint's handlers,
+validators, and data access. Each expected behavior must be traceable to a
+code location (`path:line`).
+
+Commits with no wire-observable surface (pure refactors, comment- or
+test-only changes) get a justified skip — derive just enough to
+demonstrate the absence of observable effect, and record the skip in
+delta-map.md as a coverage-gap entry exactly like an unexecuted matrix row.
+
+**Fan-out (optional intensity):** if the delta map reaches 10 or more
+wire-observable deltas (default threshold; the interview may override
+either way), fan out per-category derivation subagents and reconcile their
+outputs into one delta-map.md. Below the threshold, derive inline.
+
+## b. No-touch inventory → no-touch.md
+
+Read the repo's contract/behavioral test sources and extract every fixture
+the tests depend on: hardcoded ids, seeded objects, counted collections.
+Record COLLECTION-LEVEL predicates, not just object ids — a test that
+counts or enumerates a collection is violated by *creating* an object that
+joins it, not only by mutating a member. Fixtures the run cannot resolve
+from source (env-var indirection, CI-time constants, external seed
+scripts) become explicit interview questions — never assumed absent.
+These objects must not be mutated, and writes that would change their
+observable state (adding a child row a test counts) are equally
+off-limits. Ask the user for additional off-limits objects and append them.
+
+## c. Deployment model → deploy-model.md
+
+Derive from the repo's infra/pipeline config how a build reaches the
+environment: canary vs. direct, promotion behavior, racing deploys. Never
+assume; phase 3 verifies empirically.
+
+## d. Build fingerprint → fingerprint.md
+
+Establish how the run recognizes the build under test, via this ladder
+(record the selected rung and the exact assertion command):
+
+1. **Build-identity endpoint** (version/build-info/assembly hash) whenever
+   the service exposes one — defect-independent, so preferred.
+2. **Unique read-observable behavior** (a new validation message or
+   endpoint the previous build lacks). Write-dependent behaviors are
+   INELIGIBLE — the fingerprint must pass before any write is permitted.
+3. **User-confirmed deploy evidence** (pipeline run + commit SHA),
+   explicitly recorded in the report as a weaker fingerprint.
+
+The fingerprint is asserted at the start AND end of every matrix script; a
+flip invalidates intervening results.
+
+**Behavior-fingerprint failure vs. build defect:** repeated rung-2 failure
+combined with confirmed deploy evidence is escalated as a candidate build
+defect in the fingerprint behavior itself — route it into the phase-5
+disposition process; do NOT loop the environment gate as "not deployed".
+
+**Rung-3 compensating control:** with nothing wire-observable to assert,
+each matrix script instead re-queries the service's deploy/pipeline
+history at start and end (via whatever access preflight established, or
+user re-confirmation when access is zero); any deploy record newer than
+the confirmed one counts as a flip and triggers the phase-5 abort/taint
+procedure. The report's fingerprint-evidence section must state that
+rung-3 runs carry undetectable-flip risk.
+
+## Gate
+
+delta-map.md, no-touch.md, deploy-model.md, and fingerprint.md all exist
+and every entry is traceable to repo head. If a new domain surfaced (a
+witness API in an uninterviewed domain), run the phase-1 re-interview
+loop-back before declaring this gate passed.
+````
+
+- [ ] **Step 2: Validate**
+
+Run: `python scripts/validate.py`
+Expected: exit 0, `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/api-tooling/api-e2e/steps/02-ground-truth.md
+git commit -m "feat(api-e2e): phase-2 ground-truth derivation step"
+```
+
+### Task 4: Create `steps/03-environment-gate.md`
+
+**Files:**
+- Create: `skills/api-tooling/api-e2e/steps/03-environment-gate.md`
+
+**Interfaces:**
+- Consumes: `fingerprint.md` (rung + assertion command), `deploy-model.md`, deploy preference from `run-context.md`.
+- Produces: gate verdict appended to `run-context.md` (`## Environment gate: PASSED <timestamp, rung, evidence>`). Step 05 re-enters this file on mid-run flips.
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+# Phase 3 — Environment gate (both modes)
+
+Verify the live environment is the build the run derived from. No matrix
+executes before this gate passes. This phase is re-entered by phase 5
+whenever a mid-run fingerprint flip is detected.
+
+## Deployed mode
+
+Verify the live build corresponds to the deployed ref recorded in the
+interview, using the phase-2d ladder (build-identity endpoint, unique
+read-observable behavior, or user-confirmed deploy evidence). On mismatch,
+STOP and reconcile with the user — either re-derive phase 2 from the
+correct ref or fix the environment. Never test against expectations
+derived from a different commit.
+
+## PR mode
+
+Assert the fingerprint against the live environment. If it already
+matches, record and proceed. If not:
+
+1. **Prefer the user deploys.** If they provide a pipeline run URL,
+   monitor it via whatever access preflight established (MCP tools, REST
+   with PAT, or the user pasting status).
+2. **If the user asks the skill to trigger the deploy:** first present the
+   exact pipeline — name, id, project — derived from the repo's pipeline
+   config, and get explicit confirmation it is the right one. Deployment
+   variables are the user's to set; offer, don't insist.
+3. **Regardless of who deploys, converge on the fingerprint:** poll until
+   3 consecutive hits (default). This guards against canary analysis
+   windows, promotion delays, and racing deploys silently replacing the
+   build — trust the fingerprint, not the pipeline's "succeeded" status.
+   Consult deploy-model.md for how long promotion is expected to take and
+   pick a polling cadence that matches; report progress to the user while
+   waiting.
+
+## Gate
+
+3 consecutive fingerprint passes (or, on rung 3, user-confirmed deploy
+evidence recorded in the report). Append the verdict, timestamp, rung, and
+evidence to run-context.md. No matrix executes before this.
+````
+
+- [ ] **Step 2: Validate**
+
+Run: `python scripts/validate.py`
+Expected: exit 0, `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/api-tooling/api-e2e/steps/03-environment-gate.md
+git commit -m "feat(api-e2e): phase-3 environment gate step"
+```
+
+### Task 5: Create `steps/04-matrix.md`
+
+**Files:**
+- Create: `skills/api-tooling/api-e2e/steps/04-matrix.md`
+
+**Interfaces:**
+- Consumes: `delta-map.md`, `no-touch.md`, `fingerprint.md`, data permissions from `run-context.md`.
+- Produces: `matrix.md` (every row: `id | delta | category | tier | fixture needs | expected`), executable `scripts/matrix-<n>.sh`, and two user approvals recorded in `run-context.md` (`## Executed-tier approval`, `## Fixture-plan approval`). Step 05 executes the scripts; step 06 reads `matrix.md` for gap accounting.
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+# Phase 4 — Matrix derivation & scripting
+
+Cross the phase-2 delta list with the invariant categories below. Every
+category is considered for every delta; every omission becomes an explicit
+coverage-gap row — never silently dropped.
+
+## Invariant categories
+
+- **Auth edges:** no token, wrong-audience token, cross-tenant access.
+- **Validation:** every validator rule, asserted on exact message text.
+- **Not-found / permission / validation precedence:** probe the ordering.
+- **Conflict paths:** each conflict producer, asserted on payload shape,
+  with **rollback verified by re-reading** the would-be-mutated object.
+- **Happy paths:** every write arm, side effects witnessed through read
+  APIs — never assumed from the status code.
+- **Attribution proofs:** for behavior depending on ambient state — create
+  the cause, observe the effect, remove the cause, observe it vanish. A
+  conflict firing against pre-existing state is not proof; one you can
+  switch on and off is.
+- **Boundary values:** min/max dates, sentinels, zero, off-by-one ranges.
+- **Negative controls:** checks that must NOT fire, proving specificity.
+- **Regression sweep:** adjacent untouched surface (sibling endpoints,
+  older API versions) still behaves as before.
+
+## Rules
+
+- **Probe before choosing.** Never assume a slot/fixture is free —
+  enumerate live state first, including inactive/cancelled objects where
+  the API hides them by default.
+- **Fixture policy (three tiers):** (1) the API under test gets
+  run-created disposable fixtures wherever a create API exists;
+  (2) surrounding reference data is used-not-mutated, with user
+  permission; (3) no-touch objects are never written to, directly or
+  observably. Where creation isn't possible via API, ask the user to
+  create or designate (phase-1 loop-back).
+- **Matrix prioritization — every row carries an explicit tier:**
+  - Tier 1 (always executed): the delta's write arms, conflict paths with
+    rollback verification, precedence changes.
+  - Tier 2 (executed unless the user trims): validation rules, auth
+    edges, boundary values, attribution proofs, negative controls.
+  - Tier 3 (sampled by default): the regression sweep.
+  The full untrimmed matrix is always preserved in matrix.md — anything
+  not executed becomes a coverage-gap row.
+- **Executed-tier approval gate (standalone, all modes):** fires even when
+  the matrix contains no writes; merges with the fixture-plan gate when
+  writes exist. The presentation MUST include an excluded-rows summary:
+  per-category counts of unexecuted rows, with the highest-risk excluded
+  rows named individually.
+- **Executable scripts** in `{scratchpad}/api-e2e/scripts/`: bash + curl +
+  jq/python; PASS/FAIL asserts on status AND body content; full response
+  capture to `{scratchpad}/api-e2e/results/`; fingerprint gates at both
+  ends (per fingerprint.md, honoring the rung-3 compensating control);
+  cleanup functions; idempotent re-run safety where possible.
+- **Fixture-plan approval gate:** before ANY write executes, present what
+  will be created, which pre-existing objects will be referenced, anything
+  irreversible, and the executed tier. Cross-check every planned
+  create/delete against no-touch.md's COLLECTION-LEVEL predicates (not
+  just object ids); collisions and unresolved fixture indirection become
+  interview questions before approval. Writes begin only on approval.
+
+## Gate
+
+User-approved executed tier (all modes) and fixture plan (when writes
+exist), both recorded in run-context.md; scripts exist with fingerprint
+gates at both ends.
+````
+
+- [ ] **Step 2: Validate**
+
+Run: `python scripts/validate.py`
+Expected: exit 0, `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/api-tooling/api-e2e/steps/04-matrix.md
+git commit -m "feat(api-e2e): phase-4 matrix derivation and gates step"
+```
+
+### Task 6: Create `steps/05-execute.md`
+
+**Files:**
+- Create: `skills/api-tooling/api-e2e/steps/05-execute.md`
+
+**Interfaces:**
+- Consumes: `scripts/matrix-<n>.sh`, `fingerprint.md` (flip semantics), `secrets/mint-<domain>.sh` (re-mint), phase-3 re-entry.
+- Produces: `results/` captures + a **disposition ledger** appended to `matrix.md` (per FAIL: `check id | disposition 1-4 | evidence`). Step 06 consumes both.
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+# Phase 5 — Execution & triage
+
+Run matrices SERIALLY — shared staging means concurrent probes corrupt
+each other's fixtures. Capture everything to results/.
+
+## The four-way FAIL disposition
+
+Every FAIL must land in exactly one bucket, recorded in the disposition
+ledger with evidence:
+
+1. **Build defect** — deployed code deviates from the derived expectation.
+   Report with reproduction (redaction happens at phase 6).
+2. **Environment/fixture assumption wrong** — prove it by probing (e.g.,
+   the slot was organically occupied), fix the fixture, rerun.
+3. **Harness bug** — script/capture error; fix the script, rerun.
+4. **Expectation mis-derived** — re-read the code, correct delta-map.md,
+   rerun.
+
+**Rule: a FAIL is not a build defect until the fixture assumption has been
+verified live.** The build being right and your fixture being wrong looks
+identical to a defect until you probe.
+
+## Mid-run events
+
+- **Token expiry** → re-mint from `secrets/mint-<domain>.sh`; resume.
+- **Fingerprint flip** (racing deploy; on rung 3, a newer deploy record) →
+  abort the current script, mark every check since the last passing
+  fingerprint assertion as TAINTED, re-enter the phase-3 environment gate,
+  and rerun tainted checks only after it passes again.
+- **Newly required domain** (a witness read needs an uninterviewed
+  domain) → phase-1 re-interview loop-back, then resume.
+
+## Gate
+
+Zero undispositioned FAILs. Every row in the executed tier is PASS,
+dispositioned, or explicitly moved to the coverage-gap list with a reason.
+````
+
+- [ ] **Step 2: Validate**
+
+Run: `python scripts/validate.py`
+Expected: exit 0, `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/api-tooling/api-e2e/steps/05-execute.md
+git commit -m "feat(api-e2e): phase-5 execution and triage step"
+```
+
+### Task 7: Create `steps/06-report.md`
+
+**Files:**
+- Create: `skills/api-tooling/api-e2e/steps/06-report.md`
+
+**Interfaces:**
+- Consumes: `matrix.md` (rows + disposition ledger), `results/`, `fingerprint.md`, report destination from `run-context.md`.
+- Produces: `{scratchpad}/api-e2e/report.md` (sanitized), delivered to the durable destination after user approval. Step 07's residual-state output is appended here before delivery — cleanup (07) runs BEFORE final delivery.
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+# Phase 6 — Report
+
+Assemble `{scratchpad}/api-e2e/report.md`. Run phase 7 (cleanup) before
+final delivery so the residual-state and cleanup-verification sections are
+real, then deliver.
+
+## Mandatory sections
+
+- **Build identity + fingerprint evidence** — what was asserted, when, at
+  both ends of every matrix; the ladder rung used. Rung-3 runs MUST state
+  they carry undetectable-flip risk.
+- **Counts** — asserted checks, passes, failures by disposition.
+- **Per-delta verification table** — delta → verified behavior → check ids.
+- **Every FAIL and its disposition** — including "the build was right"
+  cases; they are positive evidence, not embarrassments.
+- **Coverage gaps** — every matrix row not executed, categorized by reason
+  (not constructible, not reachable, not approved / lower tier, derivation
+  skipped), why, and where that behavior is covered instead
+  (unit/contract). Never silent.
+- **Residual state** — everything the run left behind, exactly (from
+  phase 7).
+- **Cleanup verification results** (from phase 7).
+
+## Redaction before delivery
+
+Strip Authorization headers, tokens, and all credential material, plus
+personally identifying fixture fields, from the ENTIRE assembled report —
+every mandatory section, including residual state, not just captured
+responses and reproductions. The user's approval pass reviews
+already-sanitized content and is never the only defense.
+
+## Delivery
+
+The report goes to the durable destination agreed at the interview, and in
+BOTH modes the user approves the content before it is published — PR
+comment in PR mode; the per-service canonical destination in deployed
+mode. The scratchpad copy remains the working artifact; the skill never
+commits reports to a repo, and no future run reads a past report as
+authority.
+
+## Gate
+
+Report assembled with all mandatory sections, redacted, user-approved, and
+delivered to the durable destination.
+````
+
+- [ ] **Step 2: Validate**
+
+Run: `python scripts/validate.py`
+Expected: exit 0, `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/api-tooling/api-e2e/steps/06-report.md
+git commit -m "feat(api-e2e): phase-6 report step"
+```
+
+### Task 8: Create `steps/07-cleanup.md`
+
+**Files:**
+- Create: `skills/api-tooling/api-e2e/steps/07-cleanup.md`
+
+**Interfaces:**
+- Consumes: fixture ledger from `matrix.md` / `run-context.md` (what the run created), `no-touch.md`.
+- Produces: residual-state + cleanup-verification sections for `report.md` (step 06 embeds them before delivery); optional memory writes; optional skill-text PR proposal presented to the user.
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+# Phase 7 — Cleanup & close-out
+
+Runs before the report's final delivery so its output sections are real.
+
+## Teardown
+
+- Delete every run-created fixture. Verify each deletion **by
+  observation** — re-read or enumerate the object and confirm it is gone
+  or cancelled — never by trusting the delete's status code. Where the API
+  soft-deletes, query with include-inactive flags to see the truth.
+- Restore user-designated mutables to their interviewed state if the user
+  asked for restoration.
+- Re-read a sample of no-touch objects (from no-touch.md, including
+  collection-level counts) and confirm they are untouched.
+- Enumerate every unavoidable leftover into the report's residual-state
+  section — exactly, with ids and final positions.
+
+## Durable learnings (optional, per doctrine)
+
+- **Local memory write:** if the run produced durable learnings (a fixture
+  recipe, a platform quirk), offer to save them to the user's LOCAL
+  per-user memory with provenance (date, run context). Scrub personally
+  identifying fixture fields first, using the same rule phase 6 applies to
+  the report. Never write run state to any repo.
+- **Skill-text PR proposal:** if the run discovered a durable METHOD
+  improvement (a better derivation technique, a new invariant category, a
+  failure-triage pattern), draft the skill-text diff and present it to the
+  user for approval. The skill never self-writes its own text.
+
+## Gate
+
+Cleanup verified by observation; report delivered (phase 6); any
+method-improvement proposal presented. The run is complete only when all
+three hold.
+````
+
+- [ ] **Step 2: Validate**
+
+Run: `python scripts/validate.py`
+Expected: exit 0, `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/api-tooling/api-e2e/steps/07-cleanup.md
+git commit -m "feat(api-e2e): phase-7 cleanup and close-out step"
+```
+
+---
+
+## Phase B — Orchestrator + registration
+
+### Task 9: Create `SKILL.md`
+
+**Files:**
+- Create: `skills/api-tooling/api-e2e/SKILL.md`
+
+**Interfaces:**
+- Consumes: all eight step files by relative reference (`steps/00-…` … `steps/07-…`) — the validator proves each reference resolves.
+- Produces: the installable skill entry point (frontmatter `name: api-e2e` is what `/api-e2e` resolves to).
+
+- [ ] **Step 1: Write the file**
+
+````markdown
+---
+name: api-e2e
+description: >
+  Interview-driven, fresh-context staging E2E validation of a backend API —
+  either an open PR (deploy + fingerprint + test) or an already-deployed
+  endpoint. Derives an exhaustive wire-expectation map from the deployed
+  repo head, gates on a build fingerprint, executes a risk-tiered test
+  matrix with rollback verification and attribution proofs, triages every
+  failure, and delivers a redacted report to a durable destination. Use
+  when the user says "run e2e against PR #N", "e2e-validate this
+  endpoint", "/api-e2e", or similar.
+argument-hint: "[PR number / PR URL / endpoint description]"
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, WebFetch, ToolSearch, TaskCreate, TaskUpdate
+---
+
+# api-e2e
+
+Orchestrator. Read each step file when its phase begins — do not preload
+them all. Run artifacts live under `{scratchpad}/api-e2e/`; create a task
+per phase for progress tracking.
+
+## Doctrine (non-negotiable, applies to every phase)
+
+1. **Three information sources.** A run derives everything from exactly:
+   (a) the deployed repository head, (b) live probing of the environment,
+   (c) the user interview. Nothing else is authoritative.
+2. **Memory policy.** Read local memories as HYPOTHESES only — every fact
+   from memory is untrusted until re-verified live; memory never
+   substitutes for repo-head derivation or pre-write probing. Write
+   durable learnings to local per-user memory only, PII-scrubbed, with
+   provenance. The repo and this skill's text carry zero run state, ever:
+   no fixture inventories, testbed files, or environment profiles are
+   committed anywhere. Reports go to a durable user-approved destination
+   as OUTPUTS only — no future run reads a past report as authority.
+   Method improvements become proposed skill-text PRs (phase 7), never
+   self-written. Rationale: blast-radius containment first (a wrong shared
+   fact would poison every teammate's runs; a wrong local memory is
+   contained and verify-live corrects it), ensemble diversity second
+   (independent fresh runs are nondeterministic in different ways — many
+   runs out-cover any curated matrix).
+3. **Method, zero environment facts.** This skill contains no service
+   names, URLs, tenant numbers, IDs, or quirks — the interview and the
+   repo head supply those per run.
+4. **Never presume — interview.** Any missing capability, credential,
+   permission, or fixture becomes a question to the user, including asking
+   the user to create fixtures in domains not exposed to the run.
+5. **Hard gates.** No test execution before the build fingerprint passes.
+   No writes before the no-touch inventory exists and the fixture plan is
+   user-approved. No run is complete without cleanup verification and the
+   delivered report.
+6. **Secrets are session-scoped.** Token-mint curls and credentials live
+   in `{scratchpad}/api-e2e/secrets/` only — never in committed,
+   persistent, or memory files, and never in the report.
+
+## Phase sequence
+
+| # | Phase | File | Exit gate |
+|---|---|---|---|
+| 0 | Preflight | [steps/00-preflight.md](steps/00-preflight.md) | Capability table complete (tool or user-mediated fallback per need) |
+| 1 | Interview | [steps/01-interview.md](steps/01-interview.md) | Verified token per known domain; mode/target/permissions explicit |
+| 2 | Ground truth | [steps/02-ground-truth.md](steps/02-ground-truth.md) | Delta map, no-touch inventory, deploy model, fingerprint — all repo-head-traceable |
+| 3 | Environment gate | [steps/03-environment-gate.md](steps/03-environment-gate.md) | 3 consecutive fingerprint passes (rung-3: user-confirmed evidence, recorded) |
+| 4 | Matrix & scripting | [steps/04-matrix.md](steps/04-matrix.md) | Executed tier approved (all modes); fixture plan approved (when writes exist) |
+| 5 | Execution & triage | [steps/05-execute.md](steps/05-execute.md) | Zero undispositioned FAILs |
+| 6 | Report | [steps/06-report.md](steps/06-report.md) | Redacted report user-approved and delivered to the durable destination |
+| 7 | Cleanup | [steps/07-cleanup.md](steps/07-cleanup.md) | Cleanup verified by observation; method-improvement proposal presented if any |
+
+Phases run in order. Two sanctioned loop-backs: any phase may re-enter
+phase 1 for a newly discovered domain (token + permissions only), and
+phase 5 re-enters phase 3 on a fingerprint flip. Phase 7 executes before
+phase 6's final delivery so residual-state and cleanup-verification
+sections are real; the gates still both apply.
+
+## Modes
+
+- **PR mode:** validate an open PR. Phase 3 includes deploy orchestration
+  (prefer user-run deploys; confirm pipeline identity before triggering).
+- **Deployed mode:** validate what is already live against the deployed
+  ref the interview collects. Phase 3 verifies identity only.
+- **Read-only degradation:** when data-permission answers are missing, the
+  run proceeds with safe verbs only (expected-rejection probes count as
+  writes) and records all write coverage as gaps — with an explicit
+  proceed-or-defer checkpoint when the delta is predominantly
+  write-dependent.
+
+## Fan-out threshold
+
+When the phase-2 delta map contains 10 or more wire-observable deltas
+(default; interview may override either way), fan out per-category
+derivation subagents in phases 2a/4 and reconcile. Below the threshold,
+derive inline.
+
+## Failure posture
+
+A FAIL is never reported as a build defect until the fixture assumption
+has been verified live (phase 5's four-way disposition). Two "failures"
+that turn out to be the build being right are positive evidence — report
+them as such.
+````
+
+- [ ] **Step 2: Validate (proves all eight step references resolve)**
+
+Run: `python scripts/validate.py`
+Expected: exit 0, `OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/api-tooling/api-e2e/SKILL.md
+git commit -m "feat(api-e2e): orchestrator SKILL.md"
+```
+
+### Task 10: Register the skill + record the resolved open question
+
+**Files:**
+- Modify: `README.md` (Skills table + Installation block)
+- Modify: `docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md` (Deferred / Open Questions section)
+
+- [ ] **Step 1: Add the README Skills-table row**
+
+In `README.md`, after the `design-coverage-scout` row of the Skills table, add:
+
+```markdown
+| [`api-e2e`](./skills/api-tooling/api-e2e/SKILL.md) | Interview-driven, fresh-context staging E2E validation of a backend API PR or deployed endpoint: repo-head-derived expectations, build fingerprinting, risk-tiered matrix, four-way failure triage, redacted durable report. |
+```
+
+- [ ] **Step 2: Add the installation symlink lines**
+
+In `README.md`, append to the symlink block:
+
+```bash
+ln -s "$PWD/skills/api-tooling/api-e2e"                  "$HOME/.claude/skills/api-e2e"
+```
+
+and to the Windows copy block:
+
+```bash
+cp -r skills/api-tooling/api-e2e                  "$HOME/.claude/skills/api-e2e"
+```
+
+- [ ] **Step 3: Record the fan-out resolution in the spec**
+
+In `docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md`, append to the
+"Subagent fan-out threshold" bullet under `### From 2026-07-10 review`:
+
+```markdown
+  **Resolved (implementation plan, 2026-07-10):** fixed default in the
+  skill text — fan out when the phase-2 delta map contains ≥ 10
+  wire-observable deltas; the interview may override in either direction.
+```
+
+- [ ] **Step 4: Full validation**
+
+Run: `python scripts/validate.py`
+Expected: exit 0, `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
+git commit -m "feat(api-e2e): register skill in README; resolve fan-out threshold open question"
+```
+
+---
+
+## Post-plan (not tasks — noted for the humans)
+
+- Symlink/copy the skill into `~/.claude/skills/` and restart the session to expose `/api-e2e`.
+- Spec acceptance criterion 1 (replay with induced fingerprint refusal + seeded harness bug) and criterion 2 (transfer run by a method-naive teammate) are manual exercises after merge.
+- Per the repo's workflow memory: run `/simplify` before raising the PR, then pr-autopilot for the PR loop.

--- a/docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md
+++ b/docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md
@@ -85,6 +85,21 @@ docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md (EDIT, Task 10 — rec
   to target-environment facts; fixture-policy "tiers" renamed "classes"
   (spec mirrored); phase-2a fan-out recorded in the spec with an
   effect-class partition; spec phase-7 gate aligned to the built files.
+- **Pre-PR review rounds (`/simplify`, preflight, pr-review-toolkit,
+  Copilot):** further polish applied to the SHIPPED files under
+  `skills/api-tooling/api-e2e/` after this plan was written — phase-2
+  sub-derivation concurrency note; read-only-degradation surfaced at the
+  phase-2 gate and phase-4 tiering; `matrix.md` named as the phase-6 report
+  source; fan-out one-liner corrected to per-effect-class (2a) /
+  per-invariant-category (4); `python3` added to the JSON-processor probe;
+  run-artifact references fully qualified with `{scratchpad}/api-e2e/`;
+  `WebFetch` dropped from `allowed-tools` (unused); phase-6/7 table gates
+  disambiguated to state delivery runs after cleanup; this doctrine-3
+  constraint scoped to the skill text. **The embedded per-task file
+  snippets below are the as-planned drafts and are NOT re-synced to these
+  later fixes — the shipped files under `skills/api-tooling/api-e2e/` are
+  authoritative. Snippet-vs-shipped drift is expected and intentional; read
+  the shipped files, not these drafts, as current skill text.**
 
 ## Phase A — Step files (each self-contained; validator passes without SKILL.md, per the pr-loop-lib precedent)
 

--- a/docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md
+++ b/docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md
@@ -14,7 +14,7 @@
 
 ## Global Constraints
 
-- Doctrine 3 (spec): skill text contains **method only — zero environment facts**. No service names, URLs, tenant/subscriber numbers, IDs, or platform quirks in any file. All examples generic ("the service", "domain A").
+- Doctrine 3 (spec): skill text contains **method only — zero environment facts**. No service names, URLs, tenant/subscriber numbers, IDs, or platform quirks in the skill text under `skills/api-tooling/api-e2e/` (the design docs under `docs/superpowers/` may name concrete context). All examples in the skill generic ("the service", "domain A").
 - Doctrine 6 (spec): token-mint curls and credentials are **session-scoped** — the skill text must direct them to the session scratchpad only, never to committed/persistent/memory files.
 - Step files are named with **two-digit prefixes** (`steps/00-preflight.md` … `steps/07-cleanup.md`), matching the pr-autopilot convention and the validator's `steps/NN-*.md` reference pattern.
 - The validator rejects line-initial `[TBD]`, `TODO: `, `[fill in`, `XXX ` outside code fences — never leave them in any file.

--- a/docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md
+++ b/docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md
@@ -16,7 +16,7 @@
 
 - Doctrine 3 (spec): skill text contains **method only — zero environment facts**. No service names, URLs, tenant/subscriber numbers, IDs, or platform quirks in any file. All examples generic ("the service", "domain A").
 - Doctrine 6 (spec): token-mint curls and credentials are **session-scoped** — the skill text must direct them to the session scratchpad only, never to committed/persistent/memory files.
-- Step files are named with **two-digit prefixes** (`steps/00-preflight.md` … `steps/07-cleanup.md`), matching the pr-autopilot convention and the validator's `steps/NN-*.md` reference pattern. (Deviation from the spec's illustrative single-digit names `steps/0-preflight.md`; recorded here deliberately.)
+- Step files are named with **two-digit prefixes** (`steps/00-preflight.md` … `steps/07-cleanup.md`), matching the pr-autopilot convention and the validator's `steps/NN-*.md` reference pattern.
 - The validator rejects line-initial `[TBD]`, `TODO: `, `[fill in`, `XXX ` outside code fences — never leave them in any file.
 - Every file UTF-8, LF or CRLF both tolerated.
 - **Resolved open question** (spec's Deferred section, decided by this plan and recorded back into the spec in Task 10): subagent fan-out in phase 2/4 triggers at a **fixed default of ≥ 10 wire-observable deltas** in the phase-2 delta map; the interview may override in either direction. Deterministic for the acceptance replay.
@@ -48,6 +48,27 @@ docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md (EDIT, Task 10 — rec
 ```
 
 ---
+
+## Deviations discovered during execution (2026-07-10)
+
+- **Spec references must be two-digit, not "illustrative":** the validator
+  scans `docs/` for backticked `steps/NN-*.md` references; the spec's
+  original single-digit names would never resolve. Spec updated to the real
+  filenames (committed alongside this note).
+- **Per-task validator green is unachievable; Tasks 2–9 consolidated into
+  one commit + one review.** Two causes: (a) the committed spec/plan
+  reference all eight step files, which only resolve once every file
+  exists; (b) until `SKILL.md` exists directly in `api-e2e/`,
+  `discover_skill_roots()` registers `steps/` itself as a skill root named
+  `steps`, and `check_file()`'s first-segment-exclusive resolution then
+  breaks every `steps/NN-*.md` reference repo-wide (37 false failures).
+  All references resolve only at the all-nine-files boundary, so that is
+  the commit boundary. Review coverage is unchanged: one consolidated
+  review checks all nine files against their per-task briefs.
+- **Upstream note (not fixed here):** `scripts/validate.py`'s exclusive
+  first-segment branch silently changes resolution semantics repo-wide
+  when a new skill directory temporarily lacks a direct `.md` — worth a
+  separate hardening PR.
 
 ## Phase A — Step files (each self-contained; validator passes without SKILL.md, per the pr-loop-lib precedent)
 

--- a/docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md
+++ b/docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md
@@ -69,6 +69,22 @@ docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md (EDIT, Task 10 — rec
   first-segment branch silently changes resolution semantics repo-wide
   when a new skill directory temporarily lacks a direct `.md` — worth a
   separate hardening PR.
+- **Phase-7 gate de-circularized (5f529de):** delivery is phase 6's gate;
+  07-cleanup's gate is cleanup-verified + sections handed to phase 6. Spec
+  gate line aligned in this commit.
+- **Phase-4 fan-out rule added to 04-matrix.md (5f529de):** SKILL.md
+  promised it, the step file lacked it.
+- **Script numbering convention (5f529de):** `scripts/matrix-<n>.sh`
+  numbering convention documented in 04-matrix.md.
+- **Disposition-ledger location pinned (5f529de):** the ledger lives at
+  `{scratchpad}/api-e2e/matrix.md` per 05-execute.md, so phase 6 has a
+  producer.
+- **Final-review fix set (this commit):** fixture-ledger producer added to
+  05/07; `{scratchpad}` token defined in SKILL.md + 00; SKILL.md step
+  links made validator-visible (backticked link text); doctrine 3 scoped
+  to target-environment facts; fixture-policy "tiers" renamed "classes"
+  (spec mirrored); phase-2a fan-out recorded in the spec with an
+  effect-class partition; spec phase-7 gate aligned to the built files.
 
 ## Phase A — Step files (each self-contained; validator passes without SKILL.md, per the pr-loop-lib precedent)
 

--- a/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
+++ b/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
@@ -1,0 +1,277 @@
+# api-e2e — Fresh-Context E2E Validation of Backend API PRs and Endpoints
+
+**Date:** 2026-07-10
+**Status:** Approved design (pre-implementation)
+**Location:** `skills/api-tooling/api-e2e/` (new `api-tooling` category)
+
+## Purpose
+
+A distributable skill that drives a thorough, staging-level end-to-end test pass
+against a backend API — either an open PR whose build must first reach the
+environment, or an already-deployed API/endpoint. The skill encodes the *method*
+that produced high-yield manual E2E passes (exhaustive diff-to-wire-expectation
+mapping, build fingerprinting, attribution proofs, rollback verification,
+disciplined failure triage) so that any teammate can run an equivalent pass
+without prior knowledge of the service.
+
+Primary target: Mindbody/Arcus staging services (shared platform mechanics:
+Identity-token auth, `staging.*` bases, ADO deploy pipelines). Secondary: any
+company backend API, because nothing platform-specific is hard-coded — auth,
+deploy, and fingerprinting are all derived or interviewed per run.
+
+## Doctrine (non-negotiables, stated at the top of SKILL.md)
+
+1. **Three information sources.** A run derives everything from exactly:
+   (a) the deployed repository head, (b) live probing of the environment,
+   (c) the user interview. Nothing else is authoritative.
+2. **Memory policy.**
+   - *Read — allowed as hypotheses only.* Local Claude memories may inform a
+     run (fixture recipes, platform quirks), but every environment fact taken
+     from memory is untrusted until re-verified live. Memory never substitutes
+     for repo-head derivation or for pre-write probing.
+   - *Write — local per-user memory only.* Runs may save durable learnings to
+     the user's local Claude memory, with provenance (date, run context).
+   - *The repo and the skill text carry zero run state, ever.* No fixture
+     inventories, testbed files, environment profiles, or run reports are
+     committed anywhere. A run that discovers a durable *method* improvement
+     proposes a skill-text PR to the user; it never self-writes it.
+   - Rationale: independent fresh runs are nondeterministic in different ways;
+     across many runs by many teammates this yields wider coverage than any
+     curated matrix, and no shared cache exists for one run's wrong "fact" to
+     poison. Per-user local memory is tolerated because it is contained to one
+     user and is error-corrected by the verify-live rule.
+3. **Skill text contains method, zero environment facts.** No service names,
+   IDs, URLs, tenant numbers, or quirks in the skill. All examples generic.
+4. **Never presume — interview.** Any missing capability, credential,
+   permission, or fixture becomes a question to the user. This includes asking
+   the user to create fixtures in domains they have not exposed to the run
+   (e.g., "I need a client configured with X; the client domain isn't available
+   to me — please create one and give me its id").
+5. **Hard gates.** No test execution before the build fingerprint passes. No
+   writes before the contract-test no-touch list is derived and the fixture
+   plan is user-approved. No run is complete without cleanup verification and
+   the report.
+6. **Secrets are session-scoped.** Token-mint curls and credentials pasted by
+   the user live in the session scratchpad only — never in any committed,
+   persistent, or memory file.
+
+## Architecture
+
+`SKILL.md` (orchestrator, ~150 lines: trigger phrases, doctrine, phase
+sequence, gate summary) plus one file per phase under `steps/`. This mirrors
+the existing `pr-autopilot` convention in this repo. Each step file ends with
+its exit gate. Optional intensity — not architecture: for large diffs, the
+matrix-derivation step may fan out per-category subagents and reconcile.
+
+Trigger phrases: "run e2e against PR #N", "e2e-validate this endpoint",
+"/api-e2e". Argument hint: `[PR number / PR URL / endpoint description]`.
+
+## Phases
+
+### 0 — Preflight: tooling & access probe (`steps/0-preflight.md`)
+
+Detect what exists on the machine: `gh`, `az`, ADO MCP tools, `curl`,
+`jq`/`python`, a local checkout of the target repo. Every gap degrades to
+"ask the user":
+
+- Repo access: local checkout at the right commit → GitHub token → (last
+  resort) user pastes specific files on request.
+- Pipeline visibility: ADO MCP → plain REST with a user-supplied PAT
+  (Build-read scope, Basic auth) → user runs the check and pastes the result.
+  Zero ADO access is acceptable: the build fingerprint, not the pipeline, is
+  ground truth for what is deployed. A raw `dev.azure.com` URL is not
+  directly fetchable without auth — never assume it is.
+
+**Gate:** the run knows, for each capability it will need, either a working
+tool or the user-mediated fallback.
+
+### 1 — Interview (`steps/1-interview.md`)
+
+Structured, back-and-forth, one topic at a time. Collect:
+
+- **Mode:** open PR (deploy + fingerprint + test) vs. already-deployed.
+- **Target:** service under test; the specific PR or endpoint(s); any
+  secondary domains the tests will need to call.
+- **Environment:** base URL(s), tenant/subscriber to use.
+- **Auth:** one token-mint curl per domain. Each is verified immediately with
+  a benign read before proceeding; expiry behavior noted for mid-run re-mint.
+- **Data permissions:** which pre-existing data the run may *reference*
+  (clients, staff, rooms, locations, …) and which objects, if any, the user
+  designates as *mutable*. Explicitly ask about anything ambiguous.
+- **Deploy preference** (PR mode): user deploys (preferred — deployment
+  variables are theirs to set), user provides a run URL to monitor, or user
+  authorizes the skill to trigger the pipeline after confirming its identity.
+- **Report destination:** a file in the session scratchpad always (handed to
+  the user, never committed by the skill); PR comment offered in PR mode.
+
+**Gate:** every domain the matrix will touch has a verified token; the mode,
+target, and data permissions are explicit.
+
+### 2 — Ground truth from repo head (`steps/2-ground-truth.md`)
+
+All derivation from the deployed commit, freshly, this run:
+
+a. **Wire-observable behavior map.** In PR mode, map every commit in the diff
+   to its observable effects: status codes, exact validation messages, error
+   payload shapes (type/title/detail/extensions), precedence ordering among
+   failures, headers (e.g., Retry-After), side effects and the read APIs that
+   witness them. In deployed mode, do the same for the target endpoint's
+   handlers, validators, and data access. The output is an explicit list of
+   expected behaviors, each traceable to a code location.
+b. **No-touch inventory.** Read the repo's contract/behavioral test sources
+   and extract every fixture the tests depend on (hardcoded ids, seeded
+   objects, counted collections). These objects must not be mutated, and
+   writes that would change their observable state (e.g., adding a child row
+   a test counts) are equally off-limits. Supplement by asking the user for
+   additional off-limits objects.
+c. **Deployment model.** Derive from the repo's infra/pipeline config how a
+   build reaches the environment (canary vs. direct, promotion behavior,
+   racing deploys). Never assume; verify empirically in phase 3.
+d. **Build fingerprint.** Choose a wire-observable behavior unique to the
+   build under test (e.g., a new validation message or endpoint the previous
+   build lacks). The fingerprint is asserted at the start AND end of every
+   matrix script; a flip invalidates intervening results.
+
+**Gate:** delta list, no-touch inventory, deployment model, and fingerprint
+all exist and are traceable to repo head.
+
+### 3 — Deploy gate — PR mode only (`steps/3-deploy-gate.md`)
+
+Fingerprint the live environment. If it already matches, proceed. If not:
+
+1. Prefer the user deploys. If they provide a pipeline run URL, monitor it via
+   whatever access preflight established.
+2. If the user asks the skill to trigger the deploy, first present the exact
+   pipeline (name, id, project) derived from repo config and get explicit
+   confirmation it is the right one.
+3. Regardless of who deploys, converge on the *fingerprint*: poll until 3
+   consecutive hits (default; guards against canary windows, promotion
+   delays, and racing deploys silently replacing the build).
+
+**Gate:** 3 consecutive fingerprint passes. No matrix executes before this.
+
+### 4 — Matrix derivation & scripting (`steps/4-matrix.md`)
+
+Cross the phase-2 delta list with invariant categories — every category is
+considered for every delta, and omissions are recorded as explicit coverage
+gaps, never silently dropped:
+
+- **Auth edges:** no token, wrong-audience token, cross-tenant access.
+- **Validation:** every validator rule, asserted on exact message text.
+- **Not-found / permission / validation precedence:** probe the ordering.
+- **Conflict paths:** each conflict producer, asserted on payload shape, and
+  **rollback verified by re-reading** the would-be-mutated object.
+- **Happy paths:** every write arm, with side effects witnessed through read
+  APIs (not assumed from the status code).
+- **Attribution proofs:** for any behavior that depends on ambient state,
+  create the cause → observe the effect → remove the cause → observe the
+  effect vanish. A conflict that fires against pre-existing state is not
+  proof; a conflict you can switch on and off is.
+- **Boundary values:** min/max dates, sentinels, zero, off-by-one on ranges.
+- **Negative controls:** checks that must NOT fire, proving specificity.
+- **Regression sweep:** adjacent untouched surface (sibling endpoints, older
+  API versions) still behaves as before.
+
+Rules:
+
+- **Probe before choosing.** Never assume a slot/fixture is free; enumerate
+  live state first (including inactive/cancelled objects where the API hides
+  them by default).
+- **Fixture policy (three tiers):** (1) the API under test gets run-created
+  disposable fixtures wherever a create API exists; (2) surrounding reference
+  data is used-not-mutated, with user permission; (3) no-touch objects are
+  never written to, directly or observably. Where creation isn't possible via
+  API, ask the user to create or designate.
+- **Executable scripts** in the session scratchpad: bash + curl + jq/python,
+  PASS/FAIL asserts on status AND body content, full response capture to a
+  results file, fingerprint gates at both ends, cleanup functions, idempotent
+  re-run safety where possible.
+- **Fixture-plan approval gate:** before any write executes, present the user
+  a plan of what will be created, which pre-existing objects will be
+  referenced, and anything irreversible. Writes begin only on approval.
+
+**Gate:** user-approved fixture plan; scripts exist with fingerprint gates.
+
+### 5 — Execution & triage (`steps/5-execute.md`)
+
+Run matrices serially (shared staging: concurrent probes corrupt each other's
+fixtures). Every FAIL must be dispositioned into exactly one of:
+
+1. **Build defect** — the deployed code deviates from the derived expectation.
+   Report it with reproduction.
+2. **Environment/fixture assumption wrong** — prove by probing (e.g., the slot
+   was organically occupied), fix the fixture, rerun.
+3. **Harness bug** — script/capture error; fix, rerun.
+4. **Expectation mis-derived** — re-read the code, correct the expectation,
+   rerun.
+
+Rule: a FAIL is not a build defect until the fixture assumption has been
+verified live. Mid-run events: token expiry → re-mint from the interview
+curl; fingerprint flip (racing deploy) → abort, mark tainted checks, re-gate
+via phase 3, rerun tainted checks.
+
+**Gate:** zero undispositioned FAILs.
+
+### 6 — Report (`steps/6-report.md`)
+
+Mandatory sections:
+
+- Build identity + fingerprint evidence (what was asserted, when, both ends).
+- Counts: asserted checks, passes, failures by disposition.
+- Per-delta verification table (delta → verified behavior → check ids).
+- Every FAIL and its disposition, including "the build was right" cases.
+- **Coverage gaps:** what was not constructible or reachable, why, and where
+  that behavior is covered instead (unit/contract). Never silent.
+- Residual state: everything the run left behind, exactly.
+- Cleanup verification results.
+
+PR mode: offer to post as a PR comment; user approves content before posting.
+
+### 7 — Cleanup (`steps/7-cleanup.md`)
+
+- Delete run-created fixtures; verify each deletion **by observation**
+  (re-read/enumerate), never by trusting the delete's status code.
+- Restore user-designated mutables to their interviewed state if the user
+  asked for restoration.
+- Re-read a sample of no-touch objects to confirm they are untouched.
+- Enumerate all unavoidable leftovers into the report's residual-state
+  section.
+
+**Gate:** cleanup verified; report delivered.
+
+## Non-goals
+
+- Not a load/performance tool.
+- Not a substitute for contract/unit/behavioral tests — it reports where
+  those are the coverage for non-constructible paths.
+- No CI integration in v1; the skill is interactive by design (the interview
+  is the interface).
+- No automated fixture creation in domains the user has not exposed.
+- No run-state persistence of any kind outside local per-user memory.
+
+## Acceptance test for the skill itself
+
+One-time manual replay: point the built skill at a previously validated PR of
+a known repo in deployed mode, with a fresh session. Verify it independently
+(a) derives a matrix covering the known delta classes, (b) refuses to execute
+when the fingerprint fails, (c) enforces the fixture-plan approval gate before
+any write, and (d) produces a report containing all mandatory sections. The
+replay produces no persisted artifacts.
+
+## Decisions log (from brainstorming)
+
+- Scope: primarily Arcus/Mindbody staging, generalizes to any company API;
+  both PR mode and already-deployed mode. (user)
+- Strict fresh context: no cross-run persistence; repo head + live probing +
+  interview are the only sources; ensemble-of-independent-runs is the
+  coverage mechanism. (user)
+- Amendment: local Claude memories may be read (as unverified hypotheses) and
+  written (per-user only); the repo/skill never carries state. (user)
+- Deploys: offer to run but confirm pipeline identity first; prefer
+  user-run deploys; accept run URLs for monitoring. (user)
+- Fixtures: create-your-own for the API under test; reuse pre-existing
+  surrounding data with permission; never touch contract-test objects or
+  their observable state. (user)
+- Architecture: orchestrator SKILL.md + steps/ files, matching pr-autopilot;
+  subagent fan-out as optional intensity in matrix derivation. (user chose
+  recommendation)

--- a/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
+++ b/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
@@ -80,7 +80,7 @@ Trigger phrases: "run e2e against PR #N", "e2e-validate this endpoint",
 
 ## Phases
 
-### 0 — Preflight: tooling & access probe (`steps/0-preflight.md`)
+### 0 — Preflight: tooling & access probe (`steps/00-preflight.md`)
 
 Detect what exists on the machine: `gh`, `az`, ADO MCP tools, `curl`,
 `jq`/`python`, a local checkout of the target repo. Every gap degrades to
@@ -97,7 +97,7 @@ Detect what exists on the machine: `gh`, `az`, ADO MCP tools, `curl`,
 **Gate:** the run knows, for each capability it will need, either a working
 tool or the user-mediated fallback.
 
-### 1 — Interview (`steps/1-interview.md`)
+### 1 — Interview (`steps/01-interview.md`)
 
 Structured, back-and-forth, one topic at a time. The interview is where the
 operator's environment knowledge enters the run — the skill supplies the
@@ -155,7 +155,7 @@ later phase that discovers a newly required domain (e.g., a side-effect
 witness API surfaced by phase 2 derivation) returns to this phase's
 token/permission procedure for that domain before proceeding.
 
-### 2 — Ground truth from repo head (`steps/2-ground-truth.md`)
+### 2 — Ground truth from repo head (`steps/02-ground-truth.md`)
 
 All derivation from the deployed commit, freshly, this run:
 
@@ -210,7 +210,7 @@ d. **Build fingerprint.** Establish how the run will recognize the build
 **Gate:** delta list, no-touch inventory, deployment model, and fingerprint
 all exist and are traceable to repo head.
 
-### 3 — Environment gate — both modes (`steps/3-environment-gate.md`)
+### 3 — Environment gate — both modes (`steps/03-environment-gate.md`)
 
 Verify the live environment is the build the run derived from, in both modes.
 
@@ -237,7 +237,7 @@ If not:
 user-confirmed deploy evidence recorded in the report). No matrix executes
 before this.
 
-### 4 — Matrix derivation & scripting (`steps/4-matrix.md`)
+### 4 — Matrix derivation & scripting (`steps/04-matrix.md`)
 
 Cross the phase-2 delta list with invariant categories — every category is
 considered for every delta, and omissions are recorded as explicit coverage
@@ -297,7 +297,7 @@ Rules:
 **Gate:** user-approved executed tier (all modes) and fixture plan (when
 writes exist); scripts exist with fingerprint gates.
 
-### 5 — Execution & triage (`steps/5-execute.md`)
+### 5 — Execution & triage (`steps/05-execute.md`)
 
 Run matrices serially (shared staging: concurrent probes corrupt each other's
 fixtures). Every FAIL must be dispositioned into exactly one of:
@@ -317,7 +317,7 @@ the phase-3 environment gate (both modes), rerun tainted checks.
 
 **Gate:** zero undispositioned FAILs.
 
-### 6 — Report (`steps/6-report.md`)
+### 6 — Report (`steps/06-report.md`)
 
 Mandatory sections:
 
@@ -343,7 +343,7 @@ in both modes the user approves the content before it is published (PR
 comment in PR mode; the per-service canonical destination in deployed mode),
 so coverage gaps survive the session.
 
-### 7 — Cleanup (`steps/7-cleanup.md`)
+### 7 — Cleanup (`steps/07-cleanup.md`)
 
 - Delete run-created fixtures; verify each deletion **by observation**
   (re-read/enumerate), never by trusting the delete's status code.

--- a/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
+++ b/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
@@ -12,7 +12,11 @@ environment, or an already-deployed API/endpoint. The skill encodes the *method*
 that produced high-yield manual E2E passes (exhaustive diff-to-wire-expectation
 mapping, build fingerprinting, attribution proofs, rollback verification,
 disciplined failure triage) so that any teammate can run an equivalent pass
-without prior knowledge of the service.
+without prior knowledge of the *method*. The operator still brings the
+environment knowledge: phase 1 states explicit operator prerequisites (access,
+base URLs, safe tenant, token-mint recipes, data-permission authority), and
+when the operator cannot supply an answer the run degrades to read-only
+rather than guessing.
 
 Primary target: Mindbody/Arcus staging services (shared platform mechanics:
 Identity-token auth, `staging.*` bases, ADO deploy pipelines). Secondary: any
@@ -32,14 +36,20 @@ deploy, and fingerprinting are all derived or interviewed per run.
    - *Write — local per-user memory only.* Runs may save durable learnings to
      the user's local Claude memory, with provenance (date, run context).
    - *The repo and the skill text carry zero run state, ever.* No fixture
-     inventories, testbed files, environment profiles, or run reports are
-     committed anywhere. A run that discovers a durable *method* improvement
-     proposes a skill-text PR to the user; it never self-writes it.
-   - Rationale: independent fresh runs are nondeterministic in different ways;
-     across many runs by many teammates this yields wider coverage than any
-     curated matrix, and no shared cache exists for one run's wrong "fact" to
-     poison. Per-user local memory is tolerated because it is contained to one
-     user and is error-corrected by the verify-live rule.
+     inventories, testbed files, or environment profiles are committed
+     anywhere. Run reports go to a durable user-approved destination
+     (phase 6) so coverage evidence survives the session — but they are
+     outputs only: no future run reads a past report as authority. A run
+     that discovers a durable *method* improvement proposes a skill-text PR
+     to the user (executed in phase 7); it never self-writes it.
+   - Rationale — blast-radius containment first, ensemble diversity second:
+     a wrong "fact" cached in shared state would poison every teammate's
+     runs, while a wrong local memory is contained to one user and is
+     error-corrected by the verify-live rule. Independent fresh runs are also
+     nondeterministic in different ways, so across many runs by many
+     teammates the team gets wider coverage than any curated matrix. This
+     deliberately trades team-level knowledge pooling for containment:
+     per-user memories will diverge, and that is accepted.
 3. **Skill text contains method, zero environment facts.** No service names,
    IDs, URLs, tenant numbers, or quirks in the skill. All examples generic.
 4. **Never presume — interview.** Any missing capability, credential,
@@ -87,25 +97,53 @@ tool or the user-mediated fallback.
 
 ### 1 — Interview (`steps/1-interview.md`)
 
-Structured, back-and-forth, one topic at a time. Collect:
+Structured, back-and-forth, one topic at a time. The interview is where the
+operator's environment knowledge enters the run — the skill supplies the
+method, the operator supplies the environment.
+
+**Operator prerequisites (stated up front):** access to the target
+environment; base URL(s) and a safe tenant/subscriber; a token-mint recipe
+per domain the tests will call; authority to designate mutable data and to
+create fixtures in domains not exposed to the run. An operator missing one
+of these is told exactly what is missing, not silently blocked.
+
+**Memory-seeded fast path:** when local memory carries prior answers for the
+target service (base URLs, tenant, token-mint recipe, data permissions),
+present them as prefilled hypotheses for one-shot confirm-or-correct instead
+of asking each topic cold — consistent with the read-as-hypotheses doctrine.
+Confirmed values remain subject to live verification.
+
+Collect:
 
 - **Mode:** open PR (deploy + fingerprint + test) vs. already-deployed.
 - **Target:** service under test; the specific PR or endpoint(s); any
   secondary domains the tests will need to call.
+- **Deployed ref** (deployed mode): which commit/branch/tag is currently
+  deployed — the input phase 2 derives from and phase 3 verifies.
 - **Environment:** base URL(s), tenant/subscriber to use.
 - **Auth:** one token-mint curl per domain. Each is verified immediately with
   a benign read before proceeding; expiry behavior noted for mid-run re-mint.
 - **Data permissions:** which pre-existing data the run may *reference*
   (clients, staff, rooms, locations, …) and which objects, if any, the user
   designates as *mutable*. Explicitly ask about anything ambiguous.
+  **Read-only fallback:** if the user cannot confidently answer a
+  data-permission or tenant-safety question, the run proceeds in read-only
+  mode (no-write matrix; write coverage recorded as gaps) until an
+  authoritative answer arrives.
 - **Deploy preference** (PR mode): user deploys (preferred — deployment
   variables are theirs to set), user provides a run URL to monitor, or user
   authorizes the skill to trigger the pipeline after confirming its identity.
-- **Report destination:** a file in the session scratchpad always (handed to
-  the user, never committed by the skill); PR comment offered in PR mode.
+- **Report destination:** a durable, user-approved destination is mandatory
+  in both modes (PR comment in PR mode; a user-chosen durable location such
+  as a wiki page or tracker entry in deployed mode), alongside the session
+  scratchpad working copy. The skill never commits reports to a repo, and no
+  future run reads a past report as authority.
 
-**Gate:** every domain the matrix will touch has a verified token; the mode,
-target, and data permissions are explicit.
+**Gate:** every interview-known domain has a verified token; the mode,
+target, and data permissions are explicit. **Re-interview loop-back:** any
+later phase that discovers a newly required domain (e.g., a side-effect
+witness API surfaced by phase 2 derivation) returns to this phase's
+token/permission procedure for that domain before proceeding.
 
 ### 2 — Ground truth from repo head (`steps/2-ground-truth.md`)
 
@@ -120,24 +158,45 @@ a. **Wire-observable behavior map.** In PR mode, map every commit in the diff
    expected behaviors, each traceable to a code location.
 b. **No-touch inventory.** Read the repo's contract/behavioral test sources
    and extract every fixture the tests depend on (hardcoded ids, seeded
-   objects, counted collections). These objects must not be mutated, and
-   writes that would change their observable state (e.g., adding a child row
-   a test counts) are equally off-limits. Supplement by asking the user for
-   additional off-limits objects.
+   objects, counted collections). Record collection-level predicates, not
+   just object ids — a test that counts or enumerates a collection is
+   violated by *creating* an object that joins it, not only by mutating a
+   member. Fixtures the run cannot resolve from source (env-var indirection,
+   CI-time constants, external seed scripts) are surfaced as explicit
+   interview questions, never assumed absent. These objects must not be
+   mutated, and writes that would change their observable state (e.g., adding
+   a child row a test counts) are equally off-limits. Supplement by asking
+   the user for additional off-limits objects.
 c. **Deployment model.** Derive from the repo's infra/pipeline config how a
    build reaches the environment (canary vs. direct, promotion behavior,
    racing deploys). Never assume; verify empirically in phase 3.
-d. **Build fingerprint.** Choose a wire-observable behavior unique to the
-   build under test (e.g., a new validation message or endpoint the previous
-   build lacks). The fingerprint is asserted at the start AND end of every
-   matrix script; a flip invalidates intervening results.
+d. **Build fingerprint.** Establish how the run will recognize the build
+   under test, via a fallback ladder: (1) a *read-observable* behavior unique
+   to the build (e.g., a new validation message or endpoint the previous
+   build lacks) — write-dependent behaviors are ineligible, since the
+   fingerprint must pass before any write is permitted; (2) a build-identity
+   endpoint (version/build-info/assembly hash) where the service exposes
+   one; (3) user-confirmed deploy evidence (pipeline run + commit SHA),
+   explicitly recorded in the report as a weaker fingerprint. The fingerprint
+   is asserted at the start AND end of every matrix script; a flip
+   invalidates intervening results.
 
 **Gate:** delta list, no-touch inventory, deployment model, and fingerprint
 all exist and are traceable to repo head.
 
-### 3 — Deploy gate — PR mode only (`steps/3-deploy-gate.md`)
+### 3 — Environment gate — both modes (`steps/3-environment-gate.md`)
 
-Fingerprint the live environment. If it already matches, proceed. If not:
+Verify the live environment is the build the run derived from, in both modes.
+
+*Deployed mode:* verify the live build corresponds to the deployed ref
+collected in phase 1, using the phase-2d fingerprint ladder (unique
+read-observable behavior, build-identity endpoint, or user-confirmed deploy
+evidence). On mismatch, stop and reconcile with the user — re-derive phase 2
+from the correct ref or fix the environment; never test against expectations
+derived from a different commit.
+
+*PR mode:* fingerprint the live environment. If it already matches, proceed.
+If not:
 
 1. Prefer the user deploys. If they provide a pipeline run URL, monitor it via
    whatever access preflight established.
@@ -148,7 +207,9 @@ Fingerprint the live environment. If it already matches, proceed. If not:
    consecutive hits (default; guards against canary windows, promotion
    delays, and racing deploys silently replacing the build).
 
-**Gate:** 3 consecutive fingerprint passes. No matrix executes before this.
+**Gate:** 3 consecutive fingerprint passes (or, on the ladder's weakest rung,
+user-confirmed deploy evidence recorded in the report). No matrix executes
+before this.
 
 ### 4 — Matrix derivation & scripting (`steps/4-matrix.md`)
 
@@ -182,13 +243,22 @@ Rules:
   data is used-not-mutated, with user permission; (3) no-touch objects are
   never written to, directly or observably. Where creation isn't possible via
   API, ask the user to create or designate.
+- **Matrix prioritization:** derived rows are tiered by risk (new writes and
+  precedence changes highest; regression sweep sampled). The full untrimmed
+  matrix is always derived and preserved — anything not executed is recorded
+  as an explicit coverage gap, never silently dropped. The user approves the
+  executed tier at the fixture-plan gate.
 - **Executable scripts** in the session scratchpad: bash + curl + jq/python,
   PASS/FAIL asserts on status AND body content, full response capture to a
   results file, fingerprint gates at both ends, cleanup functions, idempotent
   re-run safety where possible.
 - **Fixture-plan approval gate:** before any write executes, present the user
   a plan of what will be created, which pre-existing objects will be
-  referenced, and anything irreversible. Writes begin only on approval.
+  referenced, anything irreversible, and the executed matrix tier. Every
+  planned create/delete is cross-checked against the no-touch inventory's
+  collection-level predicates (not just object ids); collisions and
+  unresolved test-fixture indirection become interview questions before
+  approval. Writes begin only on approval.
 
 **Gate:** user-approved fixture plan; scripts exist with fingerprint gates.
 
@@ -207,8 +277,8 @@ fixtures). Every FAIL must be dispositioned into exactly one of:
 
 Rule: a FAIL is not a build defect until the fixture assumption has been
 verified live. Mid-run events: token expiry → re-mint from the interview
-curl; fingerprint flip (racing deploy) → abort, mark tainted checks, re-gate
-via phase 3, rerun tainted checks.
+curl; fingerprint flip (racing deploy) → abort, mark tainted checks, re-enter
+the phase-3 environment gate (both modes), rerun tainted checks.
 
 **Gate:** zero undispositioned FAILs.
 
@@ -225,7 +295,16 @@ Mandatory sections:
 - Residual state: everything the run left behind, exactly.
 - Cleanup verification results.
 
-PR mode: offer to post as a PR comment; user approves content before posting.
+**Redaction before delivery:** strip Authorization headers, tokens, and other
+credential material, plus personally identifying fixture fields, from
+captured responses and reproductions before report content is assembled —
+the user's approval pass reviews already-sanitized content and is never the
+only defense.
+
+Delivery: the report goes to the durable destination agreed in phase 1
+(PR comment in PR mode — user approves content before posting; the
+user-chosen durable location in deployed mode), so coverage gaps survive the
+session.
 
 ### 7 — Cleanup (`steps/7-cleanup.md`)
 
@@ -236,8 +315,12 @@ PR mode: offer to post as a PR comment; user approves content before posting.
 - Re-read a sample of no-touch objects to confirm they are untouched.
 - Enumerate all unavoidable leftovers into the report's residual-state
   section.
+- If the run discovered a durable *method* improvement, draft the skill-text
+  diff and present it to the user for approval — the doctrine-2 "propose a
+  skill-text PR" behavior executes here, before the run is complete.
 
-**Gate:** cleanup verified; report delivered.
+**Gate:** cleanup verified; report delivered; any method-improvement proposal
+presented.
 
 ## Non-goals
 
@@ -247,16 +330,29 @@ PR mode: offer to post as a PR comment; user approves content before posting.
 - No CI integration in v1; the skill is interactive by design (the interview
   is the interface).
 - No automated fixture creation in domains the user has not exposed.
-- No run-state persistence of any kind outside local per-user memory.
+- No run-state persistence of any kind outside local per-user memory; run
+  reports are delivered to user-owned durable destinations but are never
+  consumed as inputs by later runs.
 
 ## Acceptance test for the skill itself
 
-One-time manual replay: point the built skill at a previously validated PR of
-a known repo in deployed mode, with a fresh session. Verify it independently
-(a) derives a matrix covering the known delta classes, (b) refuses to execute
-when the fingerprint fails, (c) enforces the fixture-plan approval gate before
-any write, and (d) produces a report containing all mandatory sections. The
-replay produces no persisted artifacts.
+Two criteria:
+
+1. **Replay (mechanism).** Point the built skill at a previously validated PR
+   of a known repo in deployed mode, with a fresh session. First derive the
+   fingerprint from a commit known NOT to be deployed and verify the run
+   refuses to execute; then re-derive from the deployed head and proceed.
+   Seed one deliberate harness bug so at least one FAIL flows through the
+   four-way disposition process. Verify the run (a) derives a matrix covering
+   the known delta classes, (b) enforced the refusal, (c) enforces the
+   fixture-plan approval gate before any write, and (d) produces a report
+   containing all mandatory sections.
+2. **Transfer (the actual product claim).** A teammate who neither authored
+   the skill nor the original manual passes completes a full run (phases 0–7)
+   against a service they have not previously tested. Any stall or
+   misunderstanding is treated as a skill-text defect, not operator error.
+
+Neither criterion persists artifacts beyond the report's durable destination.
 
 ## Decisions log (from brainstorming)
 
@@ -275,3 +371,16 @@ replay produces no persisted artifacts.
 - Architecture: orchestrator SKILL.md + steps/ files, matching pr-autopilot;
   subagent fan-out as optional intensity in matrix derivation. (user chose
   recommendation)
+- ce-doc-review round 1 (2026-07-10): 6 personas, 14 actionable findings —
+  13 applied via best-judgment routing, 1 deferred below. (review)
+
+## Deferred / Open Questions
+
+### From 2026-07-10 review
+
+- **Subagent fan-out threshold (Architecture / Phase 4):** "large diffs" has
+  no defined criterion (commit count, endpoint count, file count), so
+  implementers must guess per run whether matrix derivation fans out — and
+  the acceptance replay cannot verify the path deterministically. Decide:
+  a fixed threshold in the skill text, or a per-run user choice at the
+  interview. (scope-guardian, P2, confidence 75)

--- a/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
+++ b/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
@@ -52,8 +52,10 @@ deploy, and fingerprinting are all derived or interviewed per run.
      teammates the team gets wider coverage than any curated matrix. This
      deliberately trades team-level knowledge pooling for containment:
      per-user memories will diverge, and that is accepted.
-3. **Skill text contains method, zero environment facts.** No service names,
-   IDs, URLs, tenant numbers, or quirks in the skill. All examples generic.
+3. **Skill text contains method, zero environment facts.** No
+   target-environment service names, IDs, URLs, tenant numbers, or quirks in
+   the skill. Generic vendor-tool examples (e.g., `gh`, `az`, an MCP server
+   name) that illustrate probing are fine.
 4. **Never presume — interview.** Any missing capability, credential,
    permission, or fixture becomes a question to the user. This includes asking
    the user to create fixtures in domains they have not exposed to the run
@@ -72,8 +74,11 @@ deploy, and fingerprinting are all derived or interviewed per run.
 `SKILL.md` (orchestrator, ~150 lines: trigger phrases, doctrine, phase
 sequence, gate summary) plus one file per phase under `steps/`. This mirrors
 the existing `pr-autopilot` convention in this repo. Each step file ends with
-its exit gate. Optional intensity — not architecture: for large diffs, the
-matrix-derivation step may fan out per-category subagents and reconcile.
+its exit gate. Optional intensity — not architecture: when the phase-2
+delta map holds 10 or more wire-observable deltas (interview-overridable),
+both the ground-truth step (phase 2a, partitioned by effect class) and the
+matrix-derivation step (phase 4, partitioned by invariant category) may
+fan out subagents and reconcile.
 
 Trigger phrases: "run e2e against PR #N", "e2e-validate this endpoint",
 "/api-e2e". Argument hint: `[PR number / PR URL / endpoint description]`.
@@ -264,7 +269,7 @@ Rules:
 - **Probe before choosing.** Never assume a slot/fixture is free; enumerate
   live state first (including inactive/cancelled objects where the API hides
   them by default).
-- **Fixture policy (three tiers):** (1) the API under test gets run-created
+- **Fixture policy (three classes):** (1) the API under test gets run-created
   disposable fixtures wherever a create API exists; (2) surrounding reference
   data is used-not-mutated, with user permission; (3) no-touch objects are
   never written to, directly or observably. Where creation isn't possible via
@@ -356,8 +361,9 @@ so coverage gaps survive the session.
   diff and present it to the user for approval — the doctrine-2 "propose a
   skill-text PR" behavior executes here, before the run is complete.
 
-**Gate:** cleanup verified; report delivered; any method-improvement proposal
-presented.
+**Gate:** cleanup verified by observation; residual-state and
+cleanup-verification sections handed to phase 6 (delivery is phase 6's gate,
+not phase 7's); any method-improvement proposal presented.
 
 ## Non-goals
 
@@ -434,6 +440,8 @@ Neither criterion persists artifacts beyond the report's durable destination.
   the acceptance replay cannot verify the path deterministically. Decide:
   a fixed threshold in the skill text, or a per-run user choice at the
   interview. (scope-guardian, P2, confidence 75)
-  **Resolved (implementation plan, 2026-07-10):** fixed default in the
-  skill text — fan out when the phase-2 delta map contains ≥ 10
-  wire-observable deltas; the interview may override in either direction.
+  **Resolved (implementation plan, 2026-07-10):** fixed default in the skill
+  text — fan out when the phase-2 delta map contains ≥ 10 wire-observable
+  deltas, in both delta-map derivation (phase 2a, partitioned by effect
+  class) and matrix derivation (phase 4, partitioned by invariant category);
+  the interview may override in either direction.

--- a/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
+++ b/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
@@ -434,3 +434,6 @@ Neither criterion persists artifacts beyond the report's durable destination.
   the acceptance replay cannot verify the path deterministically. Decide:
   a fixed threshold in the skill text, or a per-run user choice at the
   interview. (scope-guardian, P2, confidence 75)
+  **Resolved (implementation plan, 2026-07-10):** fixed default in the
+  skill text — fan out when the phase-2 delta map contains ≥ 10
+  wire-observable deltas; the interview may override in either direction.

--- a/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
+++ b/docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md
@@ -35,6 +35,8 @@ deploy, and fingerprinting are all derived or interviewed per run.
      for repo-head derivation or for pre-write probing.
    - *Write — local per-user memory only.* Runs may save durable learnings to
      the user's local Claude memory, with provenance (date, run context).
+     Anything saved is scrubbed of personally identifying fixture fields
+     first, using the same rule phase 6 applies before report delivery.
    - *The repo and the skill text carry zero run state, ever.* No fixture
      inventories, testbed files, or environment profiles are committed
      anywhere. Run reports go to a durable user-approved destination
@@ -128,16 +130,24 @@ Collect:
   designates as *mutable*. Explicitly ask about anything ambiguous.
   **Read-only fallback:** if the user cannot confidently answer a
   data-permission or tenant-safety question, the run proceeds in read-only
-  mode (no-write matrix; write coverage recorded as gaps) until an
-  authoritative answer arrives.
+  mode until an authoritative answer arrives. Read-only means safe verbs
+  only — write-verb requests, including expected-rejection probes (e.g., a
+  POST asserted to 400), count as write coverage and are recorded as gaps.
+  When the phase-2 delta map shows the target's coverage is predominantly
+  write-dependent, the run states the projected coverage of a read-only
+  pass and obtains an explicit proceed-or-defer decision before continuing
+  past phase 2.
 - **Deploy preference** (PR mode): user deploys (preferred — deployment
   variables are theirs to set), user provides a run URL to monitor, or user
   authorizes the skill to trigger the pipeline after confirming its identity.
 - **Report destination:** a durable, user-approved destination is mandatory
-  in both modes (PR comment in PR mode; a user-chosen durable location such
-  as a wiki page or tracker entry in deployed mode), alongside the session
-  scratchpad working copy. The skill never commits reports to a repo, and no
-  future run reads a past report as authority.
+  in both modes, alongside the session scratchpad working copy. PR mode uses
+  the PR itself (comment). Deployed mode uses one canonical per-service
+  destination (e.g., a fixed per-service wiki index page every deployed-mode
+  run appends its report to), agreed once and confirmed at interview — so
+  the union of runs stays observable instead of scattering across ad-hoc
+  locations. The skill never commits reports to a repo, and no future run
+  reads a past report as authority.
 
 **Gate:** every interview-known domain has a verified token; the mode,
 target, and data permissions are explicit. **Re-interview loop-back:** any
@@ -155,7 +165,11 @@ a. **Wire-observable behavior map.** In PR mode, map every commit in the diff
    failures, headers (e.g., Retry-After), side effects and the read APIs that
    witness them. In deployed mode, do the same for the target endpoint's
    handlers, validators, and data access. The output is an explicit list of
-   expected behaviors, each traceable to a code location.
+   expected behaviors, each traceable to a code location. Commits with no
+   wire-observable surface (pure refactors, comment- or test-only changes)
+   get a justified skip — derive just enough to demonstrate the absence of
+   observable effect, and record the skip as a coverage-gap entry exactly
+   like an unexecuted matrix row.
 b. **No-touch inventory.** Read the repo's contract/behavioral test sources
    and extract every fixture the tests depend on (hardcoded ids, seeded
    objects, counted collections). Record collection-level predicates, not
@@ -171,15 +185,27 @@ c. **Deployment model.** Derive from the repo's infra/pipeline config how a
    build reaches the environment (canary vs. direct, promotion behavior,
    racing deploys). Never assume; verify empirically in phase 3.
 d. **Build fingerprint.** Establish how the run will recognize the build
-   under test, via a fallback ladder: (1) a *read-observable* behavior unique
+   under test, via a fallback ladder: (1) a build-identity endpoint
+   (version/build-info/assembly hash) whenever the service exposes one —
+   defect-independent, so preferred; (2) a *read-observable* behavior unique
    to the build (e.g., a new validation message or endpoint the previous
    build lacks) — write-dependent behaviors are ineligible, since the
-   fingerprint must pass before any write is permitted; (2) a build-identity
-   endpoint (version/build-info/assembly hash) where the service exposes
-   one; (3) user-confirmed deploy evidence (pipeline run + commit SHA),
-   explicitly recorded in the report as a weaker fingerprint. The fingerprint
-   is asserted at the start AND end of every matrix script; a flip
-   invalidates intervening results.
+   fingerprint must pass before any write is permitted; (3) user-confirmed
+   deploy evidence (pipeline run + commit SHA), explicitly recorded in the
+   report as a weaker fingerprint. The fingerprint is asserted at the start
+   AND end of every matrix script; a flip invalidates intervening results.
+   **Behavior-fingerprint failure vs. build defect:** repeated rung-2
+   fingerprint failure combined with confirmed deploy evidence is escalated
+   as a candidate build defect in the fingerprint behavior itself — it
+   enters the phase-5 disposition process rather than looping the
+   environment gate as "not deployed". **Rung-3 compensating control:** with
+   no wire-observable fingerprint to assert, each matrix script instead
+   re-queries the service's deploy/pipeline history at start and end (via
+   whatever access preflight established, or user re-confirmation when
+   access is zero); any deploy record newer than the confirmed one counts as
+   a flip and triggers the phase-5 abort/taint procedure, and the report's
+   fingerprint-evidence section must state that rung-3 runs carry
+   undetectable-flip risk.
 
 **Gate:** delta list, no-touch inventory, deployment model, and fingerprint
 all exist and are traceable to repo head.
@@ -189,8 +215,8 @@ all exist and are traceable to repo head.
 Verify the live environment is the build the run derived from, in both modes.
 
 *Deployed mode:* verify the live build corresponds to the deployed ref
-collected in phase 1, using the phase-2d fingerprint ladder (unique
-read-observable behavior, build-identity endpoint, or user-confirmed deploy
+collected in phase 1, using the phase-2d fingerprint ladder (build-identity
+endpoint, unique read-observable behavior, or user-confirmed deploy
 evidence). On mismatch, stop and reconcile with the user — re-derive phase 2
 from the correct ref or fix the environment; never test against expectations
 derived from a different commit.
@@ -243,11 +269,19 @@ Rules:
   data is used-not-mutated, with user permission; (3) no-touch objects are
   never written to, directly or observably. Where creation isn't possible via
   API, ask the user to create or designate.
-- **Matrix prioritization:** derived rows are tiered by risk (new writes and
-  precedence changes highest; regression sweep sampled). The full untrimmed
-  matrix is always derived and preserved — anything not executed is recorded
-  as an explicit coverage gap, never silently dropped. The user approves the
-  executed tier at the fixture-plan gate.
+- **Matrix prioritization:** every derived row carries an explicit risk
+  tier. Tier 1 (always executed): the delta's write arms, conflict paths
+  with rollback verification, and precedence changes. Tier 2 (executed
+  unless the user trims): validation rules, auth edges, boundary values,
+  attribution proofs, and negative controls. Tier 3 (sampled by default):
+  the regression sweep of adjacent untouched surface. The full untrimmed
+  matrix is always preserved — anything not executed is recorded as an
+  explicit coverage gap, never silently dropped.
+- **Executed-tier approval gate:** a standalone pre-execution gate in all
+  modes — it fires even when the matrix contains no writes, and merges with
+  the fixture-plan gate when writes exist. The approval presentation
+  includes an excluded-rows summary: per-category counts of unexecuted
+  rows, with the highest-risk excluded rows named individually.
 - **Executable scripts** in the session scratchpad: bash + curl + jq/python,
   PASS/FAIL asserts on status AND body content, full response capture to a
   results file, fingerprint gates at both ends, cleanup functions, idempotent
@@ -260,7 +294,8 @@ Rules:
   unresolved test-fixture indirection become interview questions before
   approval. Writes begin only on approval.
 
-**Gate:** user-approved fixture plan; scripts exist with fingerprint gates.
+**Gate:** user-approved executed tier (all modes) and fixture plan (when
+writes exist); scripts exist with fingerprint gates.
 
 ### 5 — Execution & triage (`steps/5-execute.md`)
 
@@ -290,21 +325,23 @@ Mandatory sections:
 - Counts: asserted checks, passes, failures by disposition.
 - Per-delta verification table (delta → verified behavior → check ids).
 - Every FAIL and its disposition, including "the build was right" cases.
-- **Coverage gaps:** what was not constructible or reachable, why, and where
-  that behavior is covered instead (unit/contract). Never silent.
+- **Coverage gaps:** every matrix row not executed, categorized by reason
+  (not constructible, not reachable, not approved / lower tier, derivation
+  skipped), why, and where that behavior is covered instead (unit/contract).
+  Never silent.
 - Residual state: everything the run left behind, exactly.
 - Cleanup verification results.
 
 **Redaction before delivery:** strip Authorization headers, tokens, and other
-credential material, plus personally identifying fixture fields, from
-captured responses and reproductions before report content is assembled —
-the user's approval pass reviews already-sanitized content and is never the
-only defense.
+credential material, plus personally identifying fixture fields, from the
+entire assembled report — every mandatory section, including residual state,
+not just captured responses and reproductions. The user's approval pass
+reviews already-sanitized content and is never the only defense.
 
-Delivery: the report goes to the durable destination agreed in phase 1
-(PR comment in PR mode — user approves content before posting; the
-user-chosen durable location in deployed mode), so coverage gaps survive the
-session.
+Delivery: the report goes to the durable destination agreed in phase 1, and
+in both modes the user approves the content before it is published (PR
+comment in PR mode; the per-service canonical destination in deployed mode),
+so coverage gaps survive the session.
 
 ### 7 — Cleanup (`steps/7-cleanup.md`)
 
@@ -348,9 +385,15 @@ Two criteria:
    fixture-plan approval gate before any write, and (d) produces a report
    containing all mandatory sections.
 2. **Transfer (the actual product claim).** A teammate who neither authored
-   the skill nor the original manual passes completes a full run (phases 0–7)
-   against a service they have not previously tested. Any stall or
-   misunderstanding is treated as a skill-text defect, not operator error.
+   the skill nor the original manual passes — but who satisfies the phase-1
+   operator prerequisites — completes a full run (phases 0–7) against a
+   service they have not previously tested. Stalls and misunderstandings
+   about the *method* (what to do next, gate confusion, derivation steps)
+   are skill-text defects; a stall on an operator prerequisite counts as a
+   defect only if the skill failed to name the missing prerequisite
+   precisely. The run satisfies the criterion only if it reaches a
+   user-approved tier that includes executed write coverage — a
+   read-only-degraded run does not count as a transfer pass.
 
 Neither criterion persists artifacts beyond the report's durable destination.
 
@@ -373,6 +416,13 @@ Neither criterion persists artifacts beyond the report's durable destination.
   recommendation)
 - ce-doc-review round 1 (2026-07-10): 6 personas, 14 actionable findings —
   13 applied via best-judgment routing, 1 deferred below. (review)
+- ce-doc-review round 2 (2026-07-10): 6 personas re-run with decision primer;
+  12 actionable findings on the round-1 fixes' composition — all 12 applied
+  (transfer criterion made evaluable, rung-3 compensating control, ladder
+  reorder, read-only write-verb boundary + checkpoint, full tier enumeration,
+  standalone tier-approval gate, whole-report redaction, both-modes delivery
+  approval, canonical per-service destination, memory PII scrub, derivation
+  skip rule, coverage-gap definition unified). (review)
 
 ## Deferred / Open Questions
 

--- a/skills/api-tooling/api-e2e/SKILL.md
+++ b/skills/api-tooling/api-e2e/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: api-e2e
+description: >
+  Interview-driven, fresh-context staging E2E validation of a backend API —
+  either an open PR (deploy + fingerprint + test) or an already-deployed
+  endpoint. Derives an exhaustive wire-expectation map from the deployed
+  repo head, gates on a build fingerprint, executes a risk-tiered test
+  matrix with rollback verification and attribution proofs, triages every
+  failure, and delivers a redacted report to a durable destination. Use
+  when the user says "run e2e against PR #N", "e2e-validate this
+  endpoint", "/api-e2e", or similar.
+argument-hint: "[PR number / PR URL / endpoint description]"
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, WebFetch, ToolSearch, TaskCreate, TaskUpdate
+---
+
+# api-e2e
+
+Orchestrator. Read each step file when its phase begins — do not preload
+them all. Run artifacts live under `{scratchpad}/api-e2e/`; create a task
+per phase for progress tracking.
+
+## Doctrine (non-negotiable, applies to every phase)
+
+1. **Three information sources.** A run derives everything from exactly:
+   (a) the deployed repository head, (b) live probing of the environment,
+   (c) the user interview. Nothing else is authoritative.
+2. **Memory policy.** Read local memories as HYPOTHESES only — every fact
+   from memory is untrusted until re-verified live; memory never
+   substitutes for repo-head derivation or pre-write probing. Write
+   durable learnings to local per-user memory only, PII-scrubbed, with
+   provenance. The repo and this skill's text carry zero run state, ever:
+   no fixture inventories, testbed files, or environment profiles are
+   committed anywhere. Reports go to a durable user-approved destination
+   as OUTPUTS only — no future run reads a past report as authority.
+   Method improvements become proposed skill-text PRs (phase 7), never
+   self-written. Rationale: blast-radius containment first (a wrong shared
+   fact would poison every teammate's runs; a wrong local memory is
+   contained and verify-live corrects it), ensemble diversity second
+   (independent fresh runs are nondeterministic in different ways — many
+   runs out-cover any curated matrix).
+3. **Method, zero environment facts.** This skill contains no service
+   names, URLs, tenant numbers, IDs, or quirks — the interview and the
+   repo head supply those per run.
+4. **Never presume — interview.** Any missing capability, credential,
+   permission, or fixture becomes a question to the user, including asking
+   the user to create fixtures in domains not exposed to the run.
+5. **Hard gates.** No test execution before the build fingerprint passes.
+   No writes before the no-touch inventory exists and the fixture plan is
+   user-approved. No run is complete without cleanup verification and the
+   delivered report.
+6. **Secrets are session-scoped.** Token-mint curls and credentials live
+   in `{scratchpad}/api-e2e/secrets/` only — never in committed,
+   persistent, or memory files, and never in the report.
+
+## Phase sequence
+
+| # | Phase | File | Exit gate |
+|---|---|---|---|
+| 0 | Preflight | [steps/00-preflight.md](steps/00-preflight.md) | Capability table complete (tool or user-mediated fallback per need) |
+| 1 | Interview | [steps/01-interview.md](steps/01-interview.md) | Verified token per known domain; mode/target/permissions explicit |
+| 2 | Ground truth | [steps/02-ground-truth.md](steps/02-ground-truth.md) | Delta map, no-touch inventory, deploy model, fingerprint — all repo-head-traceable |
+| 3 | Environment gate | [steps/03-environment-gate.md](steps/03-environment-gate.md) | 3 consecutive fingerprint passes (rung-3: user-confirmed evidence, recorded) |
+| 4 | Matrix & scripting | [steps/04-matrix.md](steps/04-matrix.md) | Executed tier approved (all modes); fixture plan approved (when writes exist) |
+| 5 | Execution & triage | [steps/05-execute.md](steps/05-execute.md) | Zero undispositioned FAILs |
+| 6 | Report | [steps/06-report.md](steps/06-report.md) | Redacted report user-approved and delivered to the durable destination |
+| 7 | Cleanup | [steps/07-cleanup.md](steps/07-cleanup.md) | Cleanup verified by observation; method-improvement proposal presented if any |
+
+Phases run in order. Two sanctioned loop-backs: any phase may re-enter
+phase 1 for a newly discovered domain (token + permissions only), and
+phase 5 re-enters phase 3 on a fingerprint flip. Phase 7 executes before
+phase 6's final delivery so residual-state and cleanup-verification
+sections are real; the gates still both apply.
+
+## Modes
+
+- **PR mode:** validate an open PR. Phase 3 includes deploy orchestration
+  (prefer user-run deploys; confirm pipeline identity before triggering).
+- **Deployed mode:** validate what is already live against the deployed
+  ref the interview collects. Phase 3 verifies identity only.
+- **Read-only degradation:** when data-permission answers are missing, the
+  run proceeds with safe verbs only (expected-rejection probes count as
+  writes) and records all write coverage as gaps — with an explicit
+  proceed-or-defer checkpoint when the delta is predominantly
+  write-dependent.
+
+## Fan-out threshold
+
+When the phase-2 delta map contains 10 or more wire-observable deltas
+(default; interview may override either way), fan out per-category
+derivation subagents in phases 2a/4 and reconcile. Below the threshold,
+derive inline.
+
+## Failure posture
+
+A FAIL is never reported as a build defect until the fixture assumption
+has been verified live (phase 5's four-way disposition). Two "failures"
+that turn out to be the build being right are positive evidence — report
+them as such.

--- a/skills/api-tooling/api-e2e/SKILL.md
+++ b/skills/api-tooling/api-e2e/SKILL.md
@@ -10,7 +10,7 @@ description: >
   when the user says "run e2e against PR #N", "e2e-validate this
   endpoint", "/api-e2e", or similar.
 argument-hint: "[PR number / PR URL / endpoint description]"
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, WebFetch, ToolSearch, TaskCreate, TaskUpdate
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, ToolSearch, TaskCreate, TaskUpdate
 ---
 
 # api-e2e
@@ -67,8 +67,8 @@ progress tracking.
 | 3 | Environment gate | [`steps/03-environment-gate.md`](steps/03-environment-gate.md) | 3 consecutive fingerprint passes (rung-3: user-confirmed evidence, recorded) |
 | 4 | Matrix & scripting | [`steps/04-matrix.md`](steps/04-matrix.md) | Executed tier approved (all modes); fixture plan approved (when writes exist) |
 | 5 | Execution & triage | [`steps/05-execute.md`](steps/05-execute.md) | Zero undispositioned FAILs |
-| 6 | Report | [`steps/06-report.md`](steps/06-report.md) | Redacted report user-approved and delivered to the durable destination |
-| 7 | Cleanup | [`steps/07-cleanup.md`](steps/07-cleanup.md) | Cleanup verified by observation; sections handed to phase 6; method-improvement proposal presented if any |
+| 6 | Report | [`steps/06-report.md`](steps/06-report.md) | Redacted report user-approved and delivered — delivery runs *after* phase 7 (see the note below the table) |
+| 7 | Cleanup | [`steps/07-cleanup.md`](steps/07-cleanup.md) | Cleanup verified by observation; sections handed to phase 6 *before* that delivery; method-improvement proposal presented if any |
 
 Phases run in order. Two sanctioned loop-backs: any phase may re-enter
 phase 1 for a newly discovered domain (token + permissions only), and

--- a/skills/api-tooling/api-e2e/SKILL.md
+++ b/skills/api-tooling/api-e2e/SKILL.md
@@ -16,8 +16,11 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, AskUserQuestion, WebF
 # api-e2e
 
 Orchestrator. Read each step file when its phase begins — do not preload
-them all. Run artifacts live under `{scratchpad}/api-e2e/`; create a task
-per phase for progress tracking.
+them all. Run artifacts live under `{scratchpad}/api-e2e/`. `{scratchpad}`
+is this session's private scratchpad/temp directory — never a repo path,
+never a shared temp dir. Resolve it to an absolute path once in phase 0 and
+substitute it in every command that mentions it. Create a task per phase for
+progress tracking.
 
 ## Doctrine (non-negotiable, applies to every phase)
 
@@ -38,9 +41,11 @@ per phase for progress tracking.
    contained and verify-live corrects it), ensemble diversity second
    (independent fresh runs are nondeterministic in different ways — many
    runs out-cover any curated matrix).
-3. **Method, zero environment facts.** This skill contains no service
-   names, URLs, tenant numbers, IDs, or quirks — the interview and the
-   repo head supply those per run.
+3. **Method, zero environment facts.** This skill contains no
+   target-environment service names, URLs, tenant numbers, IDs, or quirks —
+   the interview and the repo head supply those per run; generic vendor-tool
+   examples (`gh`, `az`, an MCP server name) that illustrate probing are
+   fine.
 4. **Never presume — interview.** Any missing capability, credential,
    permission, or fixture becomes a question to the user, including asking
    the user to create fixtures in domains not exposed to the run.
@@ -56,14 +61,14 @@ per phase for progress tracking.
 
 | # | Phase | File | Exit gate |
 |---|---|---|---|
-| 0 | Preflight | [steps/00-preflight.md](steps/00-preflight.md) | Capability table complete (tool or user-mediated fallback per need) |
-| 1 | Interview | [steps/01-interview.md](steps/01-interview.md) | Verified token per known domain; mode/target/permissions explicit |
-| 2 | Ground truth | [steps/02-ground-truth.md](steps/02-ground-truth.md) | Delta map, no-touch inventory, deploy model, fingerprint — all repo-head-traceable |
-| 3 | Environment gate | [steps/03-environment-gate.md](steps/03-environment-gate.md) | 3 consecutive fingerprint passes (rung-3: user-confirmed evidence, recorded) |
-| 4 | Matrix & scripting | [steps/04-matrix.md](steps/04-matrix.md) | Executed tier approved (all modes); fixture plan approved (when writes exist) |
-| 5 | Execution & triage | [steps/05-execute.md](steps/05-execute.md) | Zero undispositioned FAILs |
-| 6 | Report | [steps/06-report.md](steps/06-report.md) | Redacted report user-approved and delivered to the durable destination |
-| 7 | Cleanup | [steps/07-cleanup.md](steps/07-cleanup.md) | Cleanup verified by observation; sections handed to phase 6; method-improvement proposal presented if any |
+| 0 | Preflight | [`steps/00-preflight.md`](steps/00-preflight.md) | Capability table complete (tool or user-mediated fallback per need) |
+| 1 | Interview | [`steps/01-interview.md`](steps/01-interview.md) | Verified token per known domain; mode/target/permissions explicit |
+| 2 | Ground truth | [`steps/02-ground-truth.md`](steps/02-ground-truth.md) | Delta map, no-touch inventory, deploy model, fingerprint — all repo-head-traceable |
+| 3 | Environment gate | [`steps/03-environment-gate.md`](steps/03-environment-gate.md) | 3 consecutive fingerprint passes (rung-3: user-confirmed evidence, recorded) |
+| 4 | Matrix & scripting | [`steps/04-matrix.md`](steps/04-matrix.md) | Executed tier approved (all modes); fixture plan approved (when writes exist) |
+| 5 | Execution & triage | [`steps/05-execute.md`](steps/05-execute.md) | Zero undispositioned FAILs |
+| 6 | Report | [`steps/06-report.md`](steps/06-report.md) | Redacted report user-approved and delivered to the durable destination |
+| 7 | Cleanup | [`steps/07-cleanup.md`](steps/07-cleanup.md) | Cleanup verified by observation; sections handed to phase 6; method-improvement proposal presented if any |
 
 Phases run in order. Two sanctioned loop-backs: any phase may re-enter
 phase 1 for a newly discovered domain (token + permissions only), and

--- a/skills/api-tooling/api-e2e/SKILL.md
+++ b/skills/api-tooling/api-e2e/SKILL.md
@@ -63,7 +63,7 @@ per phase for progress tracking.
 | 4 | Matrix & scripting | [steps/04-matrix.md](steps/04-matrix.md) | Executed tier approved (all modes); fixture plan approved (when writes exist) |
 | 5 | Execution & triage | [steps/05-execute.md](steps/05-execute.md) | Zero undispositioned FAILs |
 | 6 | Report | [steps/06-report.md](steps/06-report.md) | Redacted report user-approved and delivered to the durable destination |
-| 7 | Cleanup | [steps/07-cleanup.md](steps/07-cleanup.md) | Cleanup verified by observation; method-improvement proposal presented if any |
+| 7 | Cleanup | [steps/07-cleanup.md](steps/07-cleanup.md) | Cleanup verified by observation; sections handed to phase 6; method-improvement proposal presented if any |
 
 Phases run in order. Two sanctioned loop-backs: any phase may re-enter
 phase 1 for a newly discovered domain (token + permissions only), and

--- a/skills/api-tooling/api-e2e/SKILL.md
+++ b/skills/api-tooling/api-e2e/SKILL.md
@@ -90,10 +90,10 @@ sections are real; the gates still both apply.
 
 ## Fan-out threshold
 
-When the phase-2 delta map contains 10 or more wire-observable deltas
-(default; interview may override either way), fan out per-category
-derivation subagents in phases 2a/4 and reconcile. Below the threshold,
-derive inline.
+At 10 or more wire-observable deltas (default; interview may override
+either way), fan out derivation subagents and reconcile — per effect class
+in phase 2a (once the running delta count reaches the threshold) and per
+invariant category in phase 4. Below the threshold, derive inline.
 
 ## Failure posture
 

--- a/skills/api-tooling/api-e2e/steps/00-preflight.md
+++ b/skills/api-tooling/api-e2e/steps/00-preflight.md
@@ -3,6 +3,10 @@
 Detect what exists on this machine. Every gap degrades to "ask the user" —
 nothing is assumed installed, and no missing tool blocks the run.
 
+Resolve `{scratchpad}` to this session's private scratchpad directory
+(absolute path) before running anything; every later phase substitutes the
+same path.
+
 Create the run workspace first:
 
 ```bash

--- a/skills/api-tooling/api-e2e/steps/00-preflight.md
+++ b/skills/api-tooling/api-e2e/steps/00-preflight.md
@@ -21,7 +21,7 @@ Run each probe; record the outcome in the Capabilities table:
 gh --version        # GitHub CLI
 az --version        # Azure CLI (optional, heaviest dependency — never required)
 curl --version
-jq --version || python --version   # at least one JSON processor
+jq --version || python3 --version || python --version   # at least one JSON processor
 git rev-parse --show-toplevel      # inside the target repo? (run from the repo if known)
 ```
 

--- a/skills/api-tooling/api-e2e/steps/00-preflight.md
+++ b/skills/api-tooling/api-e2e/steps/00-preflight.md
@@ -36,7 +36,9 @@ servers may be absent in headless runs; treat absence as a normal gap.
 head, so one of these must exist:
 1. A local checkout the run can `git -C <path>` into at the right commit.
 2. A GitHub (or equivalent) token the user pastes — verify with one benign
-   API read before recording it as working.
+   API read, then record only that this rung works. The token itself goes to
+   `{scratchpad}/api-e2e/secrets/` like any credential — never into
+   run-context.md or any other artifact.
 3. Last resort: the user pastes specific files on request. Acceptable but
    slow; tell the user derivation quality depends on what they paste.
 

--- a/skills/api-tooling/api-e2e/steps/00-preflight.md
+++ b/skills/api-tooling/api-e2e/steps/00-preflight.md
@@ -1,0 +1,71 @@
+# Phase 0 — Preflight: tooling & access probe
+
+Detect what exists on this machine. Every gap degrades to "ask the user" —
+nothing is assumed installed, and no missing tool blocks the run.
+
+Create the run workspace first:
+
+```bash
+mkdir -p "{scratchpad}/api-e2e/secrets" "{scratchpad}/api-e2e/scripts" "{scratchpad}/api-e2e/results"
+```
+
+## Probe (non-fatal, one pass)
+
+Run each probe; record the outcome in the Capabilities table:
+
+```bash
+gh --version        # GitHub CLI
+az --version        # Azure CLI (optional, heaviest dependency — never required)
+curl --version
+jq --version || python --version   # at least one JSON processor
+git rev-parse --show-toplevel      # inside the target repo? (run from the repo if known)
+```
+
+For MCP-provided pipeline tools (e.g., an Azure DevOps MCP server), use
+ToolSearch with a keyword query like "pipelines get build" — presence of
+matching tools means MCP access exists. Interactively-authenticated MCP
+servers may be absent in headless runs; treat absence as a normal gap.
+
+## Access ladders (record the selected rung per capability)
+
+**Target repo access** — the run derives everything from the deployed repo
+head, so one of these must exist:
+1. A local checkout the run can `git -C <path>` into at the right commit.
+2. A GitHub (or equivalent) token the user pastes — verify with one benign
+   API read before recording it as working.
+3. Last resort: the user pastes specific files on request. Acceptable but
+   slow; tell the user derivation quality depends on what they paste.
+
+**Pipeline visibility** (PR mode deploy monitoring only — zero pipeline
+access is acceptable because the build fingerprint, not the pipeline, is
+ground truth for what is deployed):
+1. MCP pipeline tools (if the probe found them).
+2. Plain REST with a user-supplied PAT (read scope for builds), Basic auth
+   via curl. A raw pipeline URL (e.g., `dev.azure.com/...`) is NOT directly
+   fetchable without auth — never assume it is.
+3. The user runs the check themselves and pastes the result.
+
+## Capabilities table
+
+Write `{scratchpad}/api-e2e/run-context.md` starting with:
+
+```markdown
+# api-e2e run context
+## Capabilities
+| capability | status | detail |
+|---|---|---|
+| repo access | tool / user-mediated | <rung + how verified> |
+| pipeline visibility | tool / user-mediated / none | <rung> |
+| http client | tool | curl <version> |
+| json processor | tool | jq / python |
+```
+
+Secrets never go into this file — mint scripts live in
+`{scratchpad}/api-e2e/secrets/` only.
+
+## Gate
+
+The run knows, for each capability it will need, either a working tool or
+the user-mediated fallback. Do not proceed to the interview until the
+Capabilities table has a row for repo access, pipeline visibility, http
+client, and JSON processor.

--- a/skills/api-tooling/api-e2e/steps/01-interview.md
+++ b/skills/api-tooling/api-e2e/steps/01-interview.md
@@ -22,7 +22,7 @@ for one-shot confirm-or-correct instead of asking each topic cold.
 Confirmed values remain hypotheses until verified live — memory never
 substitutes for probing.
 
-## Collect (in order; append each answer to run-context.md)
+## Collect (in order; append each answer to `{scratchpad}/api-e2e/run-context.md`)
 
 1. **Mode** — open PR (deploy + fingerprint + test) vs. already-deployed.
 2. **Target** — service under test; the PR or endpoint(s); any secondary

--- a/skills/api-tooling/api-e2e/steps/01-interview.md
+++ b/skills/api-tooling/api-e2e/steps/01-interview.md
@@ -1,0 +1,74 @@
+# Phase 1 — Interview
+
+Structured, back-and-forth, one topic at a time. The interview is where the
+operator's environment knowledge enters the run — the skill supplies the
+method, the operator supplies the environment. Never presume: any missing
+capability, credential, permission, or fixture becomes a question. Use
+AskUserQuestion for crisp either/or choices; plain prose for open answers.
+
+## Operator prerequisites — state these up front
+
+The operator must bring: access to the target environment; base URL(s) and
+a safe tenant; a token-mint recipe per domain the tests will call;
+authority to designate mutable data and to create fixtures in domains not
+exposed to the run. If a prerequisite is missing, name exactly which one —
+never silently block.
+
+## Memory-seeded fast path
+
+If local memory carries prior answers for this service (base URLs, tenant,
+token-mint recipe, data permissions), present them as prefilled hypotheses
+for one-shot confirm-or-correct instead of asking each topic cold.
+Confirmed values remain hypotheses until verified live — memory never
+substitutes for probing.
+
+## Collect (in order; append each answer to run-context.md)
+
+1. **Mode** — open PR (deploy + fingerprint + test) vs. already-deployed.
+2. **Target** — service under test; the PR or endpoint(s); any secondary
+   domains the tests will call.
+3. **Deployed ref** (deployed mode only) — which commit/branch/tag is live.
+   This is what phase 2 derives from and phase 3 verifies. If the ref is a
+   branch name, resolve and record the commit SHA now — branches move.
+4. **Environment** — base URL(s); tenant/subscriber to use.
+5. **Auth** — one token-mint curl per domain. Save each as
+   `{scratchpad}/api-e2e/secrets/mint-<domain>.sh`; run it; verify the
+   token with a benign read against that domain before accepting it; note
+   expiry behavior for mid-run re-mint. Secrets live ONLY under
+   `secrets/` — never in run-context.md, reports, memory, or any commit.
+6. **Data permissions** — which pre-existing data the run may *reference*
+   (read/associate, never mutate) and which objects the user designates
+   *mutable*. Ask explicitly about anything ambiguous.
+   **Read-only fallback:** if the user cannot confidently answer a
+   data-permission or tenant-safety question, the run proceeds read-only
+   until an authoritative answer arrives. Read-only means safe verbs only —
+   write-verb requests, INCLUDING expected-rejection probes (a POST
+   asserted to 400), count as write coverage and are recorded as gaps.
+   If the phase-2 delta map later shows coverage is predominantly
+   write-dependent, state the projected coverage of a read-only pass and
+   get an explicit proceed-or-defer decision before continuing past
+   phase 2.
+7. **Deploy preference** (PR mode) — prefer the user deploys (deployment
+   variables are theirs); or the user provides a pipeline run URL to
+   monitor; or the user authorizes the skill to trigger the pipeline —
+   only after confirming its exact identity (phase 3).
+8. **Report destination** — a durable, user-approved destination is
+   mandatory in both modes, alongside the scratchpad working copy.
+   PR mode: the PR itself (comment). Deployed mode: ONE canonical
+   per-service destination (e.g., a fixed per-service wiki index page every
+   deployed-mode run appends to), agreed once and confirmed here — so the
+   union of runs stays observable. The skill never commits reports to a
+   repo; no future run reads a past report as authority.
+
+## Re-interview loop-back (referenced by later phases)
+
+When any later phase discovers a newly required domain (e.g., a
+side-effect witness API surfaced by phase-2 derivation), return HERE for
+that domain only: collect its token-mint curl, verify with a benign read,
+record its data permissions, then resume the interrupted phase.
+
+## Gate
+
+Every interview-known domain has a verified token; mode, target, and data
+permissions are explicit in run-context.md. Do not start derivation until
+this holds.

--- a/skills/api-tooling/api-e2e/steps/02-ground-truth.md
+++ b/skills/api-tooling/api-e2e/steps/02-ground-truth.md
@@ -4,6 +4,10 @@ Everything is derived from the deployed commit, freshly, this run. The
 three information sources are the repo head, live probing, and the
 interview — a memory hint may point you at code, but the code decides.
 
+Sub-derivations a, b, and c read disjoint sources and don't depend on one
+another — derive them concurrently. Only d's rung 2 consumes a's delta
+map, so defer d until a is done when rung 2 is selected.
+
 ## a. Wire-observable behavior map → delta-map.md
 
 PR mode: map EVERY commit in the diff to its observable effects — status
@@ -79,4 +83,6 @@ rung-3 runs carry undetectable-flip risk.
 delta-map.md, no-touch.md, deploy-model.md, and fingerprint.md all exist
 and every entry is traceable to repo head. If a new domain surfaced (a
 witness API in an uninterviewed domain), run the phase-1 re-interview
-loop-back before declaring this gate passed.
+loop-back before declaring this gate passed. If the run is read-only
+(phase 1, item 6) and delta-map.md is predominantly write-dependent, fire
+the proceed-or-defer checkpoint before declaring this gate passed.

--- a/skills/api-tooling/api-e2e/steps/02-ground-truth.md
+++ b/skills/api-tooling/api-e2e/steps/02-ground-truth.md
@@ -8,6 +8,9 @@ Sub-derivations a, b, and c read disjoint sources and don't depend on one
 another — derive them concurrently. Only d's rung 2 consumes a's delta
 map, so defer d until a is done when rung 2 is selected.
 
+The artifacts named below (delta-map.md, no-touch.md, deploy-model.md,
+fingerprint.md) all live under `{scratchpad}/api-e2e/` — never repo-relative.
+
 ## a. Wire-observable behavior map → delta-map.md
 
 PR mode: map EVERY commit in the diff to its observable effects — status

--- a/skills/api-tooling/api-e2e/steps/02-ground-truth.md
+++ b/skills/api-tooling/api-e2e/steps/02-ground-truth.md
@@ -19,10 +19,12 @@ test-only changes) get a justified skip — derive just enough to
 demonstrate the absence of observable effect, and record the skip in
 delta-map.md as a coverage-gap entry exactly like an unexecuted matrix row.
 
-**Fan-out (optional intensity):** if the delta map reaches 10 or more
-wire-observable deltas (default threshold; the interview may override
-either way), fan out per-category derivation subagents and reconcile their
-outputs into one delta-map.md. Below the threshold, derive inline.
+**Fan-out (optional intensity):** derive inline until the running delta
+count crosses 10 or more wire-observable deltas (default threshold; the
+interview may override either way), then fan out the remaining derivation
+across per-effect-class subagents — one per effect class (status codes,
+validation messages, payload shapes, precedence ordering, headers,
+side-effect witnesses) — and reconcile all outputs into one delta-map.md.
 
 ## b. No-touch inventory → no-touch.md
 

--- a/skills/api-tooling/api-e2e/steps/02-ground-truth.md
+++ b/skills/api-tooling/api-e2e/steps/02-ground-truth.md
@@ -1,0 +1,80 @@
+# Phase 2 — Ground truth from repo head
+
+Everything is derived from the deployed commit, freshly, this run. The
+three information sources are the repo head, live probing, and the
+interview — a memory hint may point you at code, but the code decides.
+
+## a. Wire-observable behavior map → delta-map.md
+
+PR mode: map EVERY commit in the diff to its observable effects — status
+codes, exact validation messages, error payload shapes
+(type/title/detail/extensions), precedence ordering among failures,
+headers (e.g., Retry-After), side effects and the read APIs that witness
+them. Deployed mode: do the same for the target endpoint's handlers,
+validators, and data access. Each expected behavior must be traceable to a
+code location (`path:line`).
+
+Commits with no wire-observable surface (pure refactors, comment- or
+test-only changes) get a justified skip — derive just enough to
+demonstrate the absence of observable effect, and record the skip in
+delta-map.md as a coverage-gap entry exactly like an unexecuted matrix row.
+
+**Fan-out (optional intensity):** if the delta map reaches 10 or more
+wire-observable deltas (default threshold; the interview may override
+either way), fan out per-category derivation subagents and reconcile their
+outputs into one delta-map.md. Below the threshold, derive inline.
+
+## b. No-touch inventory → no-touch.md
+
+Read the repo's contract/behavioral test sources and extract every fixture
+the tests depend on: hardcoded ids, seeded objects, counted collections.
+Record COLLECTION-LEVEL predicates, not just object ids — a test that
+counts or enumerates a collection is violated by *creating* an object that
+joins it, not only by mutating a member. Fixtures the run cannot resolve
+from source (env-var indirection, CI-time constants, external seed
+scripts) become explicit interview questions — never assumed absent.
+These objects must not be mutated, and writes that would change their
+observable state (adding a child row a test counts) are equally
+off-limits. Ask the user for additional off-limits objects and append them.
+
+## c. Deployment model → deploy-model.md
+
+Derive from the repo's infra/pipeline config how a build reaches the
+environment: canary vs. direct, promotion behavior, racing deploys. Never
+assume; phase 3 verifies empirically.
+
+## d. Build fingerprint → fingerprint.md
+
+Establish how the run recognizes the build under test, via this ladder
+(record the selected rung and the exact assertion command):
+
+1. **Build-identity endpoint** (version/build-info/assembly hash) whenever
+   the service exposes one — defect-independent, so preferred.
+2. **Unique read-observable behavior** (a new validation message or
+   endpoint the previous build lacks). Write-dependent behaviors are
+   INELIGIBLE — the fingerprint must pass before any write is permitted.
+3. **User-confirmed deploy evidence** (pipeline run + commit SHA),
+   explicitly recorded in the report as a weaker fingerprint.
+
+The fingerprint is asserted at the start AND end of every matrix script; a
+flip invalidates intervening results.
+
+**Behavior-fingerprint failure vs. build defect:** repeated rung-2 failure
+combined with confirmed deploy evidence is escalated as a candidate build
+defect in the fingerprint behavior itself — route it into the phase-5
+disposition process; do NOT loop the environment gate as "not deployed".
+
+**Rung-3 compensating control:** with nothing wire-observable to assert,
+each matrix script instead re-queries the service's deploy/pipeline
+history at start and end (via whatever access preflight established, or
+user re-confirmation when access is zero); any deploy record newer than
+the confirmed one counts as a flip and triggers the phase-5 abort/taint
+procedure. The report's fingerprint-evidence section must state that
+rung-3 runs carry undetectable-flip risk.
+
+## Gate
+
+delta-map.md, no-touch.md, deploy-model.md, and fingerprint.md all exist
+and every entry is traceable to repo head. If a new domain surfaced (a
+witness API in an uninterviewed domain), run the phase-1 re-interview
+loop-back before declaring this gate passed.

--- a/skills/api-tooling/api-e2e/steps/03-environment-gate.md
+++ b/skills/api-tooling/api-e2e/steps/03-environment-gate.md
@@ -29,12 +29,13 @@ matches, record and proceed. If not:
    3 consecutive hits (default). This guards against canary analysis
    windows, promotion delays, and racing deploys silently replacing the
    build — trust the fingerprint, not the pipeline's "succeeded" status.
-   Consult deploy-model.md for how long promotion is expected to take and
-   pick a polling cadence that matches; report progress to the user while
-   waiting.
+   Consult `{scratchpad}/api-e2e/deploy-model.md` for how long promotion is
+   expected to take and pick a polling cadence that matches; report progress
+   to the user while waiting.
 
 ## Gate
 
 3 consecutive fingerprint passes (or, on rung 3, user-confirmed deploy
 evidence recorded in the report). Append the verdict, timestamp, rung, and
-evidence to run-context.md. No matrix executes before this.
+evidence to `{scratchpad}/api-e2e/run-context.md`. No matrix executes before
+this.

--- a/skills/api-tooling/api-e2e/steps/03-environment-gate.md
+++ b/skills/api-tooling/api-e2e/steps/03-environment-gate.md
@@ -1,0 +1,40 @@
+# Phase 3 — Environment gate (both modes)
+
+Verify the live environment is the build the run derived from. No matrix
+executes before this gate passes. This phase is re-entered by phase 5
+whenever a mid-run fingerprint flip is detected.
+
+## Deployed mode
+
+Verify the live build corresponds to the deployed ref recorded in the
+interview, using the phase-2d ladder (build-identity endpoint, unique
+read-observable behavior, or user-confirmed deploy evidence). On mismatch,
+STOP and reconcile with the user — either re-derive phase 2 from the
+correct ref or fix the environment. Never test against expectations
+derived from a different commit.
+
+## PR mode
+
+Assert the fingerprint against the live environment. If it already
+matches, record and proceed. If not:
+
+1. **Prefer the user deploys.** If they provide a pipeline run URL,
+   monitor it via whatever access preflight established (MCP tools, REST
+   with PAT, or the user pasting status).
+2. **If the user asks the skill to trigger the deploy:** first present the
+   exact pipeline — name, id, project — derived from the repo's pipeline
+   config, and get explicit confirmation it is the right one. Deployment
+   variables are the user's to set; offer, don't insist.
+3. **Regardless of who deploys, converge on the fingerprint:** poll until
+   3 consecutive hits (default). This guards against canary analysis
+   windows, promotion delays, and racing deploys silently replacing the
+   build — trust the fingerprint, not the pipeline's "succeeded" status.
+   Consult deploy-model.md for how long promotion is expected to take and
+   pick a polling cadence that matches; report progress to the user while
+   waiting.
+
+## Gate
+
+3 consecutive fingerprint passes (or, on rung 3, user-confirmed deploy
+evidence recorded in the report). Append the verdict, timestamp, rung, and
+evidence to run-context.md. No matrix executes before this.

--- a/skills/api-tooling/api-e2e/steps/04-matrix.md
+++ b/skills/api-tooling/api-e2e/steps/04-matrix.md
@@ -1,0 +1,65 @@
+# Phase 4 — Matrix derivation & scripting
+
+Cross the phase-2 delta list with the invariant categories below. Every
+category is considered for every delta; every omission becomes an explicit
+coverage-gap row — never silently dropped.
+
+## Invariant categories
+
+- **Auth edges:** no token, wrong-audience token, cross-tenant access.
+- **Validation:** every validator rule, asserted on exact message text.
+- **Not-found / permission / validation precedence:** probe the ordering.
+- **Conflict paths:** each conflict producer, asserted on payload shape,
+  with **rollback verified by re-reading** the would-be-mutated object.
+- **Happy paths:** every write arm, side effects witnessed through read
+  APIs — never assumed from the status code.
+- **Attribution proofs:** for behavior depending on ambient state — create
+  the cause, observe the effect, remove the cause, observe it vanish. A
+  conflict firing against pre-existing state is not proof; one you can
+  switch on and off is.
+- **Boundary values:** min/max dates, sentinels, zero, off-by-one ranges.
+- **Negative controls:** checks that must NOT fire, proving specificity.
+- **Regression sweep:** adjacent untouched surface (sibling endpoints,
+  older API versions) still behaves as before.
+
+## Rules
+
+- **Probe before choosing.** Never assume a slot/fixture is free —
+  enumerate live state first, including inactive/cancelled objects where
+  the API hides them by default.
+- **Fixture policy (three tiers):** (1) the API under test gets
+  run-created disposable fixtures wherever a create API exists;
+  (2) surrounding reference data is used-not-mutated, with user
+  permission; (3) no-touch objects are never written to, directly or
+  observably. Where creation isn't possible via API, ask the user to
+  create or designate (phase-1 loop-back).
+- **Matrix prioritization — every row carries an explicit tier:**
+  - Tier 1 (always executed): the delta's write arms, conflict paths with
+    rollback verification, precedence changes.
+  - Tier 2 (executed unless the user trims): validation rules, auth
+    edges, boundary values, attribution proofs, negative controls.
+  - Tier 3 (sampled by default): the regression sweep.
+  The full untrimmed matrix is always preserved in matrix.md — anything
+  not executed becomes a coverage-gap row.
+- **Executed-tier approval gate (standalone, all modes):** fires even when
+  the matrix contains no writes; merges with the fixture-plan gate when
+  writes exist. The presentation MUST include an excluded-rows summary:
+  per-category counts of unexecuted rows, with the highest-risk excluded
+  rows named individually.
+- **Executable scripts** in `{scratchpad}/api-e2e/scripts/`: bash + curl +
+  jq/python; PASS/FAIL asserts on status AND body content; full response
+  capture to `{scratchpad}/api-e2e/results/`; fingerprint gates at both
+  ends (per fingerprint.md, honoring the rung-3 compensating control);
+  cleanup functions; idempotent re-run safety where possible.
+- **Fixture-plan approval gate:** before ANY write executes, present what
+  will be created, which pre-existing objects will be referenced, anything
+  irreversible, and the executed tier. Cross-check every planned
+  create/delete against no-touch.md's COLLECTION-LEVEL predicates (not
+  just object ids); collisions and unresolved fixture indirection become
+  interview questions before approval. Writes begin only on approval.
+
+## Gate
+
+User-approved executed tier (all modes) and fixture plan (when writes
+exist), both recorded in run-context.md; scripts exist with fingerprint
+gates at both ends.

--- a/skills/api-tooling/api-e2e/steps/04-matrix.md
+++ b/skills/api-tooling/api-e2e/steps/04-matrix.md
@@ -4,6 +4,9 @@ Cross the phase-2 delta list with the invariant categories below. Every
 category is considered for every delta; every omission becomes an explicit
 coverage-gap row — never silently dropped.
 
+Artifact names here (matrix.md, no-touch.md, fingerprint.md, run-context.md)
+refer to `{scratchpad}/api-e2e/` — never repo-relative files.
+
 ## Invariant categories
 
 - **Auth edges:** no token, wrong-audience token, cross-tenant access.

--- a/skills/api-tooling/api-e2e/steps/04-matrix.md
+++ b/skills/api-tooling/api-e2e/steps/04-matrix.md
@@ -27,7 +27,7 @@ coverage-gap row — never silently dropped.
 - **Probe before choosing.** Never assume a slot/fixture is free —
   enumerate live state first, including inactive/cancelled objects where
   the API hides them by default.
-- **Fixture policy (three tiers):** (1) the API under test gets
+- **Fixture policy (three classes):** (1) the API under test gets
   run-created disposable fixtures wherever a create API exists;
   (2) surrounding reference data is used-not-mutated, with user
   permission; (3) no-touch objects are never written to, directly or
@@ -46,16 +46,17 @@ coverage-gap row — never silently dropped.
   writes exist. The presentation MUST include an excluded-rows summary:
   per-category counts of unexecuted rows, with the highest-risk excluded
   rows named individually.
-- **Fan-out (optional intensity):** when the delta map crossed here holds
-  10 or more wire-observable deltas (default threshold; the interview may
+- **Fan-out (optional intensity):** when the phase-2 delta map holds 10 or
+  more wire-observable deltas (default threshold; the interview may
   override either way), fan out per-category matrix-derivation subagents —
   one per invariant category — and reconcile their rows into matrix.md
   before tiering. Below the threshold, derive inline.
-- **Executable scripts** in `{scratchpad}/api-e2e/scripts/matrix-<n>.sh` (numbered in execution order): bash + curl +
-  jq/python; PASS/FAIL asserts on status AND body content; full response
-  capture to `{scratchpad}/api-e2e/results/`; fingerprint gates at both
-  ends (per fingerprint.md, honoring the rung-3 compensating control);
-  cleanup functions; idempotent re-run safety where possible.
+- **Executable scripts** in `{scratchpad}/api-e2e/scripts/matrix-<n>.sh`
+  (numbered in execution order): bash + curl + jq/python; PASS/FAIL
+  asserts on status AND body content; full response capture to
+  `{scratchpad}/api-e2e/results/`; fingerprint gates at both ends (per
+  fingerprint.md, honoring the rung-3 compensating control); cleanup
+  functions; idempotent re-run safety where possible.
 - **Fixture-plan approval gate:** before ANY write executes, present what
   will be created, which pre-existing objects will be referenced, anything
   irreversible, and the executed tier. Cross-check every planned

--- a/skills/api-tooling/api-e2e/steps/04-matrix.md
+++ b/skills/api-tooling/api-e2e/steps/04-matrix.md
@@ -41,6 +41,9 @@ coverage-gap row — never silently dropped.
   - Tier 3 (sampled by default): the regression sweep.
   The full untrimmed matrix is always preserved in matrix.md — anything
   not executed becomes a coverage-gap row.
+  - Read-only-degraded runs (phase 1/2): write-arm and conflict rows
+    cannot execute regardless of tier — they move wholesale to
+    coverage-gap rows, leaving the read-only checks as the executed set.
 - **Executed-tier approval gate (standalone, all modes):** fires even when
   the matrix contains no writes; merges with the fixture-plan gate when
   writes exist. The presentation MUST include an excluded-rows summary:

--- a/skills/api-tooling/api-e2e/steps/04-matrix.md
+++ b/skills/api-tooling/api-e2e/steps/04-matrix.md
@@ -46,7 +46,12 @@ coverage-gap row — never silently dropped.
   writes exist. The presentation MUST include an excluded-rows summary:
   per-category counts of unexecuted rows, with the highest-risk excluded
   rows named individually.
-- **Executable scripts** in `{scratchpad}/api-e2e/scripts/`: bash + curl +
+- **Fan-out (optional intensity):** when the delta map crossed here holds
+  10 or more wire-observable deltas (default threshold; the interview may
+  override either way), fan out per-category matrix-derivation subagents —
+  one per invariant category — and reconcile their rows into matrix.md
+  before tiering. Below the threshold, derive inline.
+- **Executable scripts** in `{scratchpad}/api-e2e/scripts/matrix-<n>.sh` (numbered in execution order): bash + curl +
   jq/python; PASS/FAIL asserts on status AND body content; full response
   capture to `{scratchpad}/api-e2e/results/`; fingerprint gates at both
   ends (per fingerprint.md, honoring the rung-3 compensating control);

--- a/skills/api-tooling/api-e2e/steps/05-execute.md
+++ b/skills/api-tooling/api-e2e/steps/05-execute.md
@@ -1,7 +1,7 @@
 # Phase 5 — Execution & triage
 
 Run matrices SERIALLY — shared staging means concurrent probes corrupt
-each other's fixtures. Capture everything to results/.
+each other's fixtures. Capture everything to `{scratchpad}/api-e2e/results/`.
 
 ## The four-way FAIL disposition
 
@@ -29,7 +29,7 @@ waiting to happen, so record it in the same breath as the write.
 
 ## Mid-run events
 
-- **Token expiry** → re-mint from `secrets/mint-<domain>.sh`; resume.
+- **Token expiry** → re-mint from `{scratchpad}/api-e2e/secrets/mint-<domain>.sh`; resume.
 - **Fingerprint flip** (racing deploy; on rung 3, a newer deploy record) →
   abort the current script, mark every check since the last passing
   fingerprint assertion as TAINTED, re-enter the phase-3 environment gate,

--- a/skills/api-tooling/api-e2e/steps/05-execute.md
+++ b/skills/api-tooling/api-e2e/steps/05-execute.md
@@ -1,0 +1,36 @@
+# Phase 5 — Execution & triage
+
+Run matrices SERIALLY — shared staging means concurrent probes corrupt
+each other's fixtures. Capture everything to results/.
+
+## The four-way FAIL disposition
+
+Every FAIL must land in exactly one bucket, recorded in the disposition
+ledger with evidence:
+
+1. **Build defect** — deployed code deviates from the derived expectation.
+   Report with reproduction (redaction happens at phase 6).
+2. **Environment/fixture assumption wrong** — prove it by probing (e.g.,
+   the slot was organically occupied), fix the fixture, rerun.
+3. **Harness bug** — script/capture error; fix the script, rerun.
+4. **Expectation mis-derived** — re-read the code, correct delta-map.md,
+   rerun.
+
+**Rule: a FAIL is not a build defect until the fixture assumption has been
+verified live.** The build being right and your fixture being wrong looks
+identical to a defect until you probe.
+
+## Mid-run events
+
+- **Token expiry** → re-mint from `secrets/mint-<domain>.sh`; resume.
+- **Fingerprint flip** (racing deploy; on rung 3, a newer deploy record) →
+  abort the current script, mark every check since the last passing
+  fingerprint assertion as TAINTED, re-enter the phase-3 environment gate,
+  and rerun tainted checks only after it passes again.
+- **Newly required domain** (a witness read needs an uninterviewed
+  domain) → phase-1 re-interview loop-back, then resume.
+
+## Gate
+
+Zero undispositioned FAILs. Every row in the executed tier is PASS,
+dispositioned, or explicitly moved to the coverage-gap list with a reason.

--- a/skills/api-tooling/api-e2e/steps/05-execute.md
+++ b/skills/api-tooling/api-e2e/steps/05-execute.md
@@ -5,8 +5,8 @@ each other's fixtures. Capture everything to results/.
 
 ## The four-way FAIL disposition
 
-Every FAIL must land in exactly one bucket, recorded in the disposition
-ledger with evidence:
+Every FAIL must land in exactly one bucket, recorded with evidence in the disposition
+ledger — a `## Disposition ledger` section appended to `{scratchpad}/api-e2e/matrix.md` (phase 6 reads it from there):
 
 1. **Build defect** — deployed code deviates from the derived expectation.
    Report with reproduction (redaction happens at phase 6).

--- a/skills/api-tooling/api-e2e/steps/05-execute.md
+++ b/skills/api-tooling/api-e2e/steps/05-execute.md
@@ -14,8 +14,8 @@ disposition ledger — a `## Disposition ledger` section appended to
 2. **Environment/fixture assumption wrong** — prove it by probing (e.g.,
    the slot was organically occupied), fix the fixture, rerun.
 3. **Harness bug** — script/capture error; fix the script, rerun.
-4. **Expectation mis-derived** — re-read the code, correct delta-map.md,
-   rerun.
+4. **Expectation mis-derived** — re-read the code, correct
+   `{scratchpad}/api-e2e/delta-map.md`, rerun.
 
 **Rule: a FAIL is not a build defect until the fixture assumption has been
 verified live.** The build being right and your fixture being wrong looks

--- a/skills/api-tooling/api-e2e/steps/05-execute.md
+++ b/skills/api-tooling/api-e2e/steps/05-execute.md
@@ -5,8 +5,9 @@ each other's fixtures. Capture everything to results/.
 
 ## The four-way FAIL disposition
 
-Every FAIL must land in exactly one bucket, recorded with evidence in the disposition
-ledger — a `## Disposition ledger` section appended to `{scratchpad}/api-e2e/matrix.md` (phase 6 reads it from there):
+Every FAIL must land in exactly one bucket, recorded with evidence in the
+disposition ledger — a `## Disposition ledger` section appended to
+`{scratchpad}/api-e2e/matrix.md` (phase 6 reads it from there):
 
 1. **Build defect** — deployed code deviates from the derived expectation.
    Report with reproduction (redaction happens at phase 6).
@@ -19,6 +20,12 @@ ledger — a `## Disposition ledger` section appended to `{scratchpad}/api-e2e/m
 **Rule: a FAIL is not a build defect until the fixture assumption has been
 verified live.** The build being right and your fixture being wrong looks
 identical to a defect until you probe.
+
+**Fixture ledger:** as each write that creates a fixture succeeds, append a
+row `fixture id | type | domain | created-by check id` to a `## Fixture
+ledger` section of `{scratchpad}/api-e2e/run-context.md`. Phase 7 tears down
+from this ledger — a fixture that never made the ledger is a cleanup failure
+waiting to happen, so record it in the same breath as the write.
 
 ## Mid-run events
 

--- a/skills/api-tooling/api-e2e/steps/06-report.md
+++ b/skills/api-tooling/api-e2e/steps/06-report.md
@@ -1,0 +1,44 @@
+# Phase 6 — Report
+
+Assemble `{scratchpad}/api-e2e/report.md`. Run phase 7 (cleanup) before
+final delivery so the residual-state and cleanup-verification sections are
+real, then deliver.
+
+## Mandatory sections
+
+- **Build identity + fingerprint evidence** — what was asserted, when, at
+  both ends of every matrix; the ladder rung used. Rung-3 runs MUST state
+  they carry undetectable-flip risk.
+- **Counts** — asserted checks, passes, failures by disposition.
+- **Per-delta verification table** — delta → verified behavior → check ids.
+- **Every FAIL and its disposition** — including "the build was right"
+  cases; they are positive evidence, not embarrassments.
+- **Coverage gaps** — every matrix row not executed, categorized by reason
+  (not constructible, not reachable, not approved / lower tier, derivation
+  skipped), why, and where that behavior is covered instead
+  (unit/contract). Never silent.
+- **Residual state** — everything the run left behind, exactly (from
+  phase 7).
+- **Cleanup verification results** (from phase 7).
+
+## Redaction before delivery
+
+Strip Authorization headers, tokens, and all credential material, plus
+personally identifying fixture fields, from the ENTIRE assembled report —
+every mandatory section, including residual state, not just captured
+responses and reproductions. The user's approval pass reviews
+already-sanitized content and is never the only defense.
+
+## Delivery
+
+The report goes to the durable destination agreed at the interview, and in
+BOTH modes the user approves the content before it is published — PR
+comment in PR mode; the per-service canonical destination in deployed
+mode. The scratchpad copy remains the working artifact; the skill never
+commits reports to a repo, and no future run reads a past report as
+authority.
+
+## Gate
+
+Report assembled with all mandatory sections, redacted, user-approved, and
+delivered to the durable destination.

--- a/skills/api-tooling/api-e2e/steps/06-report.md
+++ b/skills/api-tooling/api-e2e/steps/06-report.md
@@ -7,8 +7,9 @@ real, then deliver.
 ## Mandatory sections
 
 Sources: the matrix rows and `## Disposition ledger` in
-`{scratchpad}/api-e2e/matrix.md`, fingerprint evidence from `fingerprint.md`,
-captured responses in `results/`, and the residual-state / cleanup sections
+`{scratchpad}/api-e2e/matrix.md`, fingerprint evidence from
+`{scratchpad}/api-e2e/fingerprint.md`, captured responses in
+`{scratchpad}/api-e2e/results/`, and the residual-state / cleanup sections
 from phase 7.
 
 - **Build identity + fingerprint evidence** — what was asserted, when, at

--- a/skills/api-tooling/api-e2e/steps/06-report.md
+++ b/skills/api-tooling/api-e2e/steps/06-report.md
@@ -6,6 +6,11 @@ real, then deliver.
 
 ## Mandatory sections
 
+Sources: the matrix rows and `## Disposition ledger` in
+`{scratchpad}/api-e2e/matrix.md`, fingerprint evidence from `fingerprint.md`,
+captured responses in `results/`, and the residual-state / cleanup sections
+from phase 7.
+
 - **Build identity + fingerprint evidence** — what was asserted, when, at
   both ends of every matrix; the ladder rung used. Rung-3 runs MUST state
   they carry undetectable-flip risk.

--- a/skills/api-tooling/api-e2e/steps/07-cleanup.md
+++ b/skills/api-tooling/api-e2e/steps/07-cleanup.md
@@ -4,7 +4,8 @@ Runs before the report's final delivery so its output sections are real.
 
 ## Teardown
 
-- Delete every run-created fixture. Verify each deletion **by
+- Delete every fixture enumerated in the `## Fixture ledger` section of
+  `{scratchpad}/api-e2e/run-context.md`. Verify each deletion **by
   observation** — re-read or enumerate the object and confirm it is gone
   or cancelled — never by trusting the delete's status code. Where the API
   soft-deletes, query with include-inactive flags to see the truth.

--- a/skills/api-tooling/api-e2e/steps/07-cleanup.md
+++ b/skills/api-tooling/api-e2e/steps/07-cleanup.md
@@ -29,6 +29,7 @@ Runs before the report's final delivery so its output sections are real.
 
 ## Gate
 
-Cleanup verified by observation; report delivered (phase 6); any
-method-improvement proposal presented. The run is complete only when all
-three hold.
+Cleanup verified by observation; residual-state and cleanup-verification
+sections handed to phase 6; any method-improvement proposal presented.
+The RUN is complete only when phase 6 then delivers the approved report —
+delivery is phase 6's gate, not this phase's.

--- a/skills/api-tooling/api-e2e/steps/07-cleanup.md
+++ b/skills/api-tooling/api-e2e/steps/07-cleanup.md
@@ -11,7 +11,7 @@ Runs before the report's final delivery so its output sections are real.
   soft-deletes, query with include-inactive flags to see the truth.
 - Restore user-designated mutables to their interviewed state if the user
   asked for restoration.
-- Re-read a sample of no-touch objects (from no-touch.md, including
+- Re-read a sample of no-touch objects (from `{scratchpad}/api-e2e/no-touch.md`, including
   collection-level counts) and confirm they are untouched.
 - Enumerate every unavoidable leftover into the report's residual-state
   section — exactly, with ids and final positions.

--- a/skills/api-tooling/api-e2e/steps/07-cleanup.md
+++ b/skills/api-tooling/api-e2e/steps/07-cleanup.md
@@ -1,0 +1,34 @@
+# Phase 7 — Cleanup & close-out
+
+Runs before the report's final delivery so its output sections are real.
+
+## Teardown
+
+- Delete every run-created fixture. Verify each deletion **by
+  observation** — re-read or enumerate the object and confirm it is gone
+  or cancelled — never by trusting the delete's status code. Where the API
+  soft-deletes, query with include-inactive flags to see the truth.
+- Restore user-designated mutables to their interviewed state if the user
+  asked for restoration.
+- Re-read a sample of no-touch objects (from no-touch.md, including
+  collection-level counts) and confirm they are untouched.
+- Enumerate every unavoidable leftover into the report's residual-state
+  section — exactly, with ids and final positions.
+
+## Durable learnings (optional, per doctrine)
+
+- **Local memory write:** if the run produced durable learnings (a fixture
+  recipe, a platform quirk), offer to save them to the user's LOCAL
+  per-user memory with provenance (date, run context). Scrub personally
+  identifying fixture fields first, using the same rule phase 6 applies to
+  the report. Never write run state to any repo.
+- **Skill-text PR proposal:** if the run discovered a durable METHOD
+  improvement (a better derivation technique, a new invariant category, a
+  failure-triage pattern), draft the skill-text diff and present it to the
+  user for approval. The skill never self-writes its own text.
+
+## Gate
+
+Cleanup verified by observation; report delivered (phase 6); any
+method-improvement proposal presented. The run is complete only when all
+three hold.


### PR DESCRIPTION
## Summary

Adds **`api-e2e`**, a self-contained skill for running thorough, interview-driven staging end-to-end test passes against a backend API PR or an already-deployed endpoint — for any company's API, not just the one it was distilled from. The method generalizes the manual PR #1152/#1153 E2E matrices: derive expected behavior fresh from the deployed repo head, verify the build under test with a fingerprint before any write, cross a delta map against nine invariant categories at risk-tiered depth, execute with witnessed side effects and adversarial failure dispositions, then redact, report, and clean up. It carries **zero environment facts** in the skill text (no company/service names, hosts, ids, or credentials) — the interview and the repo head supply those per run — so a teammate can run an equivalent pass with no prior knowledge of the service.

## Files Changed

| File | Change | Summary |
|------|--------|---------|
| `skills/api-tooling/api-e2e/SKILL.md` | Added | Orchestrator: doctrine, phase table with gates, modes, fan-out threshold, failure posture |
| `skills/api-tooling/api-e2e/steps/00-preflight.md` | Added | Phase 0 — capability/tool-access probing with user-mediated fallbacks |
| `skills/api-tooling/api-e2e/steps/01-interview.md` | Added | Phase 1 — interview: mode, target, auth mint recipes, data permissions, report destination |
| `skills/api-tooling/api-e2e/steps/02-ground-truth.md` | Added | Phase 2 — delta map, no-touch inventory, deploy model, build fingerprint from repo head |
| `skills/api-tooling/api-e2e/steps/03-environment-gate.md` | Added | Phase 3 — verify the build under test via fingerprint before testing |
| `skills/api-tooling/api-e2e/steps/04-matrix.md` | Added | Phase 4 — matrix derivation (9 invariant categories × risk tiers), fixture policy, approval gates |
| `skills/api-tooling/api-e2e/steps/05-execute.md` | Added | Phase 5 — execution, disposition ledger, four-way FAIL triage, fixture ledger |
| `skills/api-tooling/api-e2e/steps/06-report.md` | Added | Phase 6 — report assembly, whole-report redaction, user-approved delivery |
| `skills/api-tooling/api-e2e/steps/07-cleanup.md` | Added | Phase 7 — teardown-by-observation before final delivery |
| `README.md` | Modified | Register the skill in the Skills table + install lines |
| `docs/superpowers/specs/2026-07-10-api-e2e-skill-design.md` | Added | Design spec (two ce-doc-review rounds applied) |
| `docs/superpowers/plans/2026-07-10-api-e2e-skill-implementation.md` | Added | Implementation plan with per-task briefs and the execution-deviations record |

## Security Impact

- [x] No security impact
- The change is markdown skill instructions and design docs — no executable auth/endpoint/DB code runs in this repo. A case-insensitive scan across all nine skill files confirmed zero leaked environment facts (company names, hosts, subscriber/pipeline ids, tokens, GUIDs). The skill's own design embeds credential-handling doctrine — secrets are session-scoped mint scripts never persisted or echoed into reports, and the report step redacts the entire assembled artifact (including residual state) before user-approved delivery.

## Testing

- Repo verify gate `python scripts/validate.py` — **green (OK)** at HEAD.
- No unit-test suite applies to markdown skill files. Quality was gated by a multi-stage review process instead: two `ce-doc-review` rounds on the spec (25 findings applied), per-task reviews during subagent-driven implementation, a full whole-branch review (4 lenses + per-finding adversarial verification — 13 findings fixed), and a pre-PR `/simplify` + preflight adversarial pass (2 + 1 findings fixed).

## Related Work

- n/a — no linked issue or ticket. Method distilled from the manual staging E2E passes on Mindbody.Scheduling PRs #1152 / #1153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
